### PR TITLE
Add accessible section menus

### DIFF
--- a/apps/web/components/messages/MessagesInterface.tsx
+++ b/apps/web/components/messages/MessagesInterface.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button, Input, Avatar, Badge, Dropdown, DropdownItem, IconButton } from '@ui';
+import { SectionMenu } from './SectionMenu';
 import { createMessage, getMessages, createChannel } from '@/actions/messages';
 import type { Database } from '@mad/db';
 
@@ -215,8 +216,18 @@ export function MessagesInterface({
                     {/* Channels */}
                     {groupedChannels.channels && (
                         <div className="p-3">
-                            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                                Channels
+                            <div
+                                className="flex items-center justify-between mb-2 group"
+                                tabIndex={0}
+                            >
+                                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                                    Channels
+                                </div>
+                                <SectionMenu
+                                    onCreate={() => setShowChannelCreate(true)}
+                                    onManage={() => console.log('Manage channels')}
+                                    className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                                />
                             </div>
                             <div className="space-y-1">
                                 {groupedChannels.channels.map((channel) => (
@@ -246,8 +257,18 @@ export function MessagesInterface({
                     {/* Project Channels */}
                     {groupedChannels.project && (
                         <div className="p-3">
-                            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                                Projects
+                            <div
+                                className="flex items-center justify-between mb-2 group"
+                                tabIndex={0}
+                            >
+                                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                                    Projects
+                                </div>
+                                <SectionMenu
+                                    onCreate={() => setShowChannelCreate(true)}
+                                    onManage={() => console.log('Manage channels')}
+                                    className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                                />
                             </div>
                             <div className="space-y-1">
                                 {groupedChannels.project.map((channel) => (
@@ -277,8 +298,18 @@ export function MessagesInterface({
                     {/* Direct Messages */}
                     {groupedChannels.direct && (
                         <div className="p-3">
-                            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                                Direct Messages
+                            <div
+                                className="flex items-center justify-between mb-2 group"
+                                tabIndex={0}
+                            >
+                                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                                    Direct Messages
+                                </div>
+                                <SectionMenu
+                                    onCreate={() => setShowChannelCreate(true)}
+                                    onManage={() => console.log('Manage channels')}
+                                    className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                                />
                             </div>
                             <div className="space-y-1">
                                 {groupedChannels.direct.map((channel) => (

--- a/apps/web/components/messages/SectionMenu.tsx
+++ b/apps/web/components/messages/SectionMenu.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Dropdown, DropdownItem, IconButton } from '@ui';
+import type { FC } from 'react';
+
+interface SectionMenuProps {
+  onCreate: () => void;
+  onManage: () => void;
+  className?: string;
+}
+
+export const SectionMenu: FC<SectionMenuProps> = ({ onCreate, onManage, className }) => (
+  <Dropdown
+    openOnHover
+    align="right"
+    className={className}
+    trigger={
+      <IconButton
+        variant="ghost"
+        size="sm"
+        aria-label="Section actions"
+        className="focus:outline-none"
+      >
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+        </svg>
+      </IconButton>
+    }
+  >
+    <DropdownItem onClick={onCreate}>Create channel</DropdownItem>
+    <DropdownItem onClick={onManage}>Manage channels</DropdownItem>
+  </Dropdown>
+);
+

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,5 @@
 export * from './client';
+import { supabaseClient } from './client';
+export const createClient = () => supabaseClient;
 export * from './project';
 export type { Database } from '../types';

--- a/packages/ui/src/Dropdown.tsx
+++ b/packages/ui/src/Dropdown.tsx
@@ -8,13 +8,18 @@ interface DropdownProps {
     children: React.ReactNode;
     align?: 'left' | 'right';
     className?: string;
+    /**
+     * When true, the dropdown opens on hover or focus instead of click.
+     */
+    openOnHover?: boolean;
 }
 
 export const Dropdown = ({
     trigger,
     children,
     align = 'left',
-    className
+    className,
+    openOnHover = false
 }: DropdownProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
@@ -30,11 +35,34 @@ export const Dropdown = ({
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, []);
 
+    const openMenu = () => setIsOpen(true);
+    const closeMenu = () => setIsOpen(false);
+    const toggleMenu = () => setIsOpen((prev) => !prev);
+
+    const triggerProps = openOnHover
+        ? {
+              onMouseEnter: openMenu,
+              onFocus: openMenu,
+              onBlur: (e: React.FocusEvent) => {
+                  if (
+                      dropdownRef.current &&
+                      e.relatedTarget &&
+                      dropdownRef.current.contains(e.relatedTarget as Node)
+                  ) {
+                      return;
+                  }
+                  closeMenu();
+              }
+          }
+        : { onClick: toggleMenu };
+
+    const containerProps = openOnHover
+        ? { onMouseLeave: closeMenu }
+        : {};
+
     return (
-        <div className="relative inline-block" ref={dropdownRef}>
-            <div onClick={() => setIsOpen(!isOpen)}>
-                {trigger}
-            </div>
+        <div className="relative inline-block" ref={dropdownRef} {...containerProps}>
+            <div {...triggerProps}>{trigger}</div>
 
             {isOpen && (
                 <div

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,4 @@
-import '@testing-library/jest-dom'; 
+import '@testing-library/jest-dom';
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';

--- a/tests/unit/sectionMenu.test.tsx
+++ b/tests/unit/sectionMenu.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SectionMenu } from '../../apps/web/components/messages/SectionMenu';
+import '@testing-library/jest-dom';
+
+describe('SectionMenu', () => {
+  it('shows menu on hover', async () => {
+    render(
+      <SectionMenu onCreate={() => {}} onManage={() => {}} />
+    );
+
+    const button = screen.getByRole('button', { name: /section actions/i });
+    expect(screen.queryByText(/create channel/i)).not.toBeInTheDocument();
+    fireEvent.mouseEnter(button);
+    expect(await screen.findByText(/create channel/i)).toBeInTheDocument();
+    fireEvent.mouseLeave(button);
+    expect(screen.queryByText(/create channel/i)).not.toBeInTheDocument();
+  });
+
+  it('shows menu on focus', async () => {
+    render(
+      <SectionMenu onCreate={() => {}} onManage={() => {}} />
+    );
+
+    const button = screen.getByRole('button', { name: /section actions/i });
+    expect(screen.queryByText(/manage channels/i)).not.toBeInTheDocument();
+    fireEvent.focus(button);
+    expect(await screen.findByText(/manage channels/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,26 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      react: path.resolve(__dirname, 'apps/web/node_modules/react'),
+      'react-dom': path.resolve(__dirname, 'apps/web/node_modules/react-dom'),
+      '@ui': path.resolve(__dirname, 'packages/ui/src/index.ts'),
+      '@ui/*': path.resolve(__dirname, 'packages/ui/src/*'),
+      '@mad/db': path.resolve(__dirname, 'packages/db/src/index.ts'),
+      '@mad/db/*': path.resolve(__dirname, 'packages/db/src/*'),
+      '@mad/db/src/*': path.resolve(__dirname, 'packages/db/src/*'),
+      '@mad/db/src': path.resolve(__dirname, 'packages/db/src')
+    }
+  },
   test: {
     globals: true,
     setupFiles: ['./tests/setup.ts'],
-    environment: 'jsdom'
+    environment: 'jsdom',
+    include: ['tests/**/*.ts?(x)'],
+    exclude: ['tests/e2e/**', 'tests/setup.ts']
   }
-}); 
+});


### PR DESCRIPTION
## Summary
- add `openOnHover` prop to dropdown for hover/focus behaviour
- create `SectionMenu` with dropdown actions
- show section menus for channel groups in messages UI
- expose `createClient` from `@mad/db`
- configure vitest paths and setup
- test section menus for hover/focus

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685b148e68248322a29a02fe5484d293