### PR TITLE
Remove quick actions sections

### DIFF
--- a/SUPABASE_INTEGRATION.md
+++ b/SUPABASE_INTEGRATION.md
@@ -228,7 +228,6 @@ The dashboard automatically:
 
 - **Real-time stats**: Project counts, task completion rates, etc.
 - **Dynamic project lists**: Shows actual projects from database
-- **Working quick actions**: Create projects, tasks, and events that persist
 - **Export functionality**: Downloads real data instead of mock data
 
 ## Error Handling

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { ProjectsGrid } from '@/components/projects';
 import { TaskTable } from '@/components/tasks';
 import { TaskSuggestions } from '@/components/ai/TaskSuggestions';
 import { SmartAnalytics } from '@/components/ai/SmartAnalytics';
-import { Plus, Download, Calendar, Users } from 'lucide-react';
+import { Plus, Download } from 'lucide-react';
 import type { Database } from '@mad/db';
 import { getProjects, createProject, getProjectStats } from '@/actions/projects';
 import { getTasks, createTask, getTaskStats } from '@/actions/tasks';
@@ -648,32 +648,6 @@ export default function DashboardPage() {
           </Card>
         </TabsContent>
       </Tabs>
-
-      {/* Quick Actions Footer */}
-      <Card className="p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <span className="text-sm font-medium text-gray-700">Quick Actions:</span>
-            <div className="flex items-center space-x-2">
-              <Button variant="ghost" onClick={() => setShowCreateTask(true)}>
-                <Plus className="w-4 h-4 mr-1" />
-                Add Task
-              </Button>
-              <Button variant="ghost" onClick={() => setShowScheduleMeeting(true)}>
-                <Calendar className="w-4 h-4 mr-1" />
-                Schedule Meeting
-              </Button>
-              <Button variant="ghost" onClick={() => setShowInviteMember(true)}>
-                <Users className="w-4 h-4 mr-1" />
-                Invite Member
-              </Button>
-            </div>
-          </div>
-          <div className="text-xs text-gray-500">
-            Last updated: {new Date().toLocaleTimeString()}
-          </div>
-        </div>
-      </Card>
 
       {/* Create Project Modal */}
       <Modal

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -58,28 +58,6 @@ export default function Sidebar() {
           ))}
         </ul>
 
-        {/* Quick Actions Section - Only when expanded */}
-        {expanded && (
-          <div className="mt-8 px-3">
-            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
-              Quick Actions
-            </div>
-            <div className="space-y-1">
-              <button className="w-full flex items-center rounded-lg p-3 text-sm font-medium text-gray-700 hover:bg-indigo-50 hover:text-indigo-600 transition-colors">
-                <svg className="h-5 w-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                </svg>
-                <span className="ml-3">New Project</span>
-              </button>
-              <button className="w-full flex items-center rounded-lg p-3 text-sm font-medium text-gray-700 hover:bg-indigo-50 hover:text-indigo-600 transition-colors">
-                <svg className="h-5 w-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                </svg>
-                <span className="ml-3">New Task</span>
-              </button>
-            </div>
-          </div>
-        )}
       </nav>
 
       {/* Footer */}


### PR DESCRIPTION
## Summary
- clean up Quick Actions links in sidebar and dashboard page
- update SUPABASE_INTEGRATION doc

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685b34ece65483228c16e3d16af2683d