### PR TITLE
Add sidebar sub navigation component

### DIFF
--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -4,6 +4,8 @@ import { Folder, Users, Calendar, MessageSquare, Settings } from 'lucide-react';
 import { WorkspaceSwitcher } from '@/components/workspace/WorkspaceSwitcher';
 import Link from 'next/link';
 import clsx from 'clsx';
+import { usePathname } from 'next/navigation';
+import SubNav from './SubNav';
 
 const nav = [
   { href: '/dashboard' as const, label: 'Projects', icon: Folder },
@@ -14,6 +16,7 @@ const nav = [
 
 export default function Sidebar() {
   const { expanded, setExpanded } = useSidebar();
+  const pathname = usePathname();
 
   return (
     <aside
@@ -42,9 +45,11 @@ export default function Sidebar() {
               <Link
                 href={item.href}
                 className={clsx(
-                  "group flex items-center rounded-lg p-3 text-sm font-medium transition-all duration-200",
-                  "hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-gray-700",
-                  "text-gray-700 dark:text-gray-300"
+                  'group flex items-center rounded-lg p-3 text-sm font-medium transition-all duration-200',
+                  'hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-gray-700',
+                  pathname === item.href
+                    ? 'bg-indigo-50 text-indigo-600 dark:bg-gray-700'
+                    : 'text-gray-700 dark:text-gray-300'
                 )}
               >
                 <item.icon className="h-5 w-5 flex-shrink-0" />
@@ -81,6 +86,9 @@ export default function Sidebar() {
           </div>
         )}
       </nav>
+
+      {/* Sub Navigation */}
+      <SubNav />
 
       {/* Footer */}
       <div className="border-t p-3">

--- a/apps/web/components/sidebar/SubNav.module.css
+++ b/apps/web/components/sidebar/SubNav.module.css
@@ -1,0 +1,11 @@
+.subNav {
+  @apply mt-4 border-t pt-4;
+}
+
+.link {
+  @apply group flex items-center rounded-lg p-2 text-sm font-medium transition-all duration-200 hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300;
+}
+
+.active {
+  @apply bg-indigo-50 text-indigo-600 dark:bg-gray-700;
+}

--- a/apps/web/components/sidebar/SubNav.tsx
+++ b/apps/web/components/sidebar/SubNav.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
+import styles from './SubNav.module.css';
+
+const subNav = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/directory', label: 'Directory' }
+] as const;
+
+export default function SubNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className={styles.subNav}>
+      <ul className="space-y-1 px-3">
+        {subNav.map(item => (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              className={clsx(
+                styles.link,
+                pathname === item.href && styles.active
+              )}
+            >
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SubNav` component with active link highlighting
- style sub navigation with `SubNav.module.css`
- update `Sidebar` to use `usePathname` for active primary links
- render `SubNav` below primary navigation

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685b34efaab48322bb6d4a1b9f29c99a