### PR TITLE
Add workspace and projects dashboards

### DIFF
--- a/apps/web/app/(protected)/dashboards/ProjectsDashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboards/ProjectsDashboard/page.tsx
@@ -1,0 +1,28 @@
+import type { Database } from '@mad/db';
+import { ProjectsGrid } from '@/components/projects';
+
+export default function ProjectsDashboard() {
+  const mockProjects: Database['public']['Tables']['projects']['Row'][] = [
+    {
+      id: 'demo',
+      workspace_id: 'ws1',
+      name: 'Demo Project',
+      description: 'Example description',
+      status: 'active',
+      progress: 0,
+      budget: 0,
+      spent: 0,
+      start_date: null,
+      end_date: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    }
+  ];
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Projects Dashboard</h1>
+      <ProjectsGrid projects={mockProjects} />
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboards/WorkspaceDashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboards/WorkspaceDashboard/page.tsx
@@ -1,0 +1,15 @@
+import { KpiCard } from '@ui';
+
+export default function WorkspaceDashboard() {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Workspace Dashboard</h1>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard title="Projects" value="--" />
+        <KpiCard title="Tasks" value="--" />
+        <KpiCard title="Team Members" value="--" />
+        <KpiCard title="Upcoming Events" value="--" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,8 +11,8 @@ export default async function RootPage() {
             // User is not authenticated, redirect to sign-in
             redirect('/sign-in');
         } else {
-            // User is authenticated, redirect to dashboard
-            redirect('/dashboard');
+            // User is authenticated, redirect to workspace dashboard
+            redirect('/dashboards/workspace');
         }
     } catch (error) {
         // If there's any error, redirect to sign-in as fallback

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import clsx from 'clsx';
 
 const nav = [
-  { href: '/dashboard' as const, label: 'Projects', icon: Folder },
+  { href: '/dashboards/projects' as const, label: 'Projects', icon: Folder },
   { href: '/directory' as const, label: 'Directory', icon: Users },
   { href: '/calendar' as const, label: 'Calendar', icon: Calendar },
   { href: '/messages' as const, label: 'Messages', icon: MessageSquare }
@@ -26,7 +26,7 @@ export default function Sidebar() {
     >
       {/* Header */}
       <div className="flex h-16 items-center border-b px-4">
-        <Link href="/dashboard" className="text-xl font-bold text-indigo-600">
+        <Link href="/dashboards/workspace" className="text-xl font-bold text-indigo-600">
           {expanded ? 'Stratus' : 'S'}
         </Link>
       </div>

--- a/apps/web/components/workspace/WorkspaceSelection.tsx
+++ b/apps/web/components/workspace/WorkspaceSelection.tsx
@@ -59,7 +59,7 @@ export function WorkspaceSelection({ userId, initialWorkspaces, initialInvitatio
   const handleWorkspaceSelect = (workspace: Workspace) => {
     // Set current workspace in local storage for session persistence
     localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
-    router.push('/dashboard');
+    router.push('/dashboards/workspace');
   };
 
   const handleCreateWorkspace = async () => {


### PR DESCRIPTION
## Summary
- create WorkspaceDashboard and ProjectsDashboard pages with placeholder metrics
- update sidebar and workspace selection to navigate to new dashboards
- redirect the root route to the workspace dashboard

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685b3e6428f483228382d1dbad5df32e