### PR TITLE
Implement SubNav and replace Tabs

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Card, KpiCard, Button, Badge, Tabs, TabsList, TabsTrigger, TabsContent, Modal, Input, Textarea, Select, Toast } from '@ui';
+import { Card, KpiCard, Button, Badge, Modal, Input, Textarea, Select, Toast, SubNav } from '@ui';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { ProjectsGrid } from '@/components/projects';
 import { TaskTable } from '@/components/tasks';
 import { TaskSuggestions } from '@/components/ai/TaskSuggestions';
@@ -120,6 +121,16 @@ export default function DashboardPage() {
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
   const [loading, setLoading] = useState(false);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const view = (searchParams.get('view') ?? 'overview') as
+    'overview' | 'ai-insights' | 'projects' | 'tasks';
+  const navItems = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'ai-insights', label: 'AI Insights' },
+    { value: 'projects', label: 'Projects' },
+    { value: 'tasks', label: 'Tasks' }
+  ] as const;
   
   // Real data state
   const [projects, setProjects] = useState<Project[]>([]);
@@ -507,17 +518,16 @@ export default function DashboardPage() {
         />
       </div>
 
-      {/* Main Content Tabs */}
-      <Tabs defaultValue="overview" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="ai-insights">AI Insights</TabsTrigger>
-          <TabsTrigger value="projects">Projects</TabsTrigger>
-          <TabsTrigger value="tasks">Tasks</TabsTrigger>
-        </TabsList>
+      <SubNav
+        items={navItems.map(n => ({
+          href: `${pathname}?view=${n.value}`,
+          label: n.label
+        }))}
+        className="mb-6"
+      />
 
-        {/* Overview Tab */}
-        <TabsContent value="overview" className="space-y-6">
+      {view === 'overview' && (
+        <div className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Recent Projects */}
             <div className="lg:col-span-2">
@@ -581,10 +591,11 @@ export default function DashboardPage() {
               </Card>
             </div>
           </div>
-        </TabsContent>
+        </div>
+      )}
 
-        {/* AI Insights Tab */}
-        <TabsContent value="ai-insights" className="space-y-6">
+      {view === 'ai-insights' && (
+        <div className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* Task Suggestions */}
             <div>
@@ -602,10 +613,11 @@ export default function DashboardPage() {
               <SmartAnalytics />
             </div>
           </div>
-        </TabsContent>
+        </div>
+      )}
 
-        {/* Projects Tab */}
-        <TabsContent value="projects" className="space-y-6">
+      {view === 'projects' && (
+        <div className="space-y-6">
           <Card className="p-6">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-xl font-semibold text-gray-900">All Projects</h2>
@@ -624,10 +636,11 @@ export default function DashboardPage() {
             </div>
             <ProjectsGrid projects={projects} />
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        {/* Tasks Tab */}
-        <TabsContent value="tasks" className="space-y-6">
+      {view === 'tasks' && (
+        <div className="space-y-6">
           <Card className="p-6">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-xl font-semibold text-gray-900">Recent Tasks</h2>
@@ -646,8 +659,8 @@ export default function DashboardPage() {
             </div>
             <TaskTable tasks={tasks} />
           </Card>
-        </TabsContent>
-      </Tabs>
+        </div>
+      )}
 
       {/* Create Project Modal */}
       <Modal

--- a/apps/web/components/settings/SettingsTabs.tsx
+++ b/apps/web/components/settings/SettingsTabs.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { useTheme } from 'next-themes';
-import { Tabs, TabsList, TabsTrigger, TabsContent, Card, Button, Input, Select, Toggle, Badge, Modal, Toast } from '@ui';
+import { Card, Button, Input, Select, Toggle, Badge, Modal, Toast, SubNav } from '@ui';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { Shield, CreditCard, AlertTriangle, Settings, Users, Key, Clock, Bell } from 'lucide-react';
 
 export function SettingsTabs() {
@@ -32,6 +33,9 @@ export function SettingsTabs() {
     const [toastMessage, setToastMessage] = useState('');
     const [toastType, setToastType] = useState<'success' | 'error'>('success');
     const [loading, setLoading] = useState(false);
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const tab = (searchParams.get('tab') ?? 'general') as 'general' | 'roles' | 'security' | 'billing' | 'danger';
 
     const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
         setToastMessage(message);
@@ -575,52 +579,25 @@ export function SettingsTabs() {
         }
     ];
 
+    const navItems = tabs.map(t => ({
+        href: `${pathname}?tab=${t.id}`,
+        label: t.label,
+        icon: t.icon
+    }));
+
     return (
         <div>
-            <Tabs defaultValue="general" className="w-full">
-                <TabsList className="mb-6">
-                    <TabsTrigger value="general" className="flex items-center gap-2">
-                        <Settings className="h-4 w-4" />
-                        General
-                    </TabsTrigger>
-                    <TabsTrigger value="roles" className="flex items-center gap-2">
-                        <Users className="h-4 w-4" />
-                        Roles & Permissions
-                    </TabsTrigger>
-                    <TabsTrigger value="security" className="flex items-center gap-2">
-                        <Shield className="h-4 w-4" />
-                        Security
-                    </TabsTrigger>
-                    <TabsTrigger value="billing" className="flex items-center gap-2">
-                        <CreditCard className="h-4 w-4" />
-                        Billing & Subscription
-                    </TabsTrigger>
-                    <TabsTrigger value="danger" className="flex items-center gap-2">
-                        <AlertTriangle className="h-4 w-4" />
-                        Danger Zone
-                    </TabsTrigger>
-                </TabsList>
+            <SubNav items={navItems} className="mb-6" />
 
-                <TabsContent value="general">
-                    {tabs[0].content}
-                </TabsContent>
+            {tab === 'general' && tabs[0].content}
 
-                <TabsContent value="roles">
-                    {tabs[1].content}
-                </TabsContent>
+            {tab === 'roles' && tabs[1].content}
 
-                <TabsContent value="security">
-                    {tabs[2].content}
-                </TabsContent>
+            {tab === 'security' && tabs[2].content}
 
-                <TabsContent value="billing">
-                    {tabs[3].content}
-                </TabsContent>
+            {tab === 'billing' && tabs[3].content}
 
-                <TabsContent value="danger">
-                    {tabs[4].content}
-                </TabsContent>
-            </Tabs>
+            {tab === 'danger' && tabs[4].content}
 
             {/* Delete Workspace Modal */}
             <Modal

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useSidebar } from './context';
 import { Folder, Users, Calendar, MessageSquare, Settings } from 'lucide-react';
+import { SubNav } from '@ui';
 import { WorkspaceSwitcher } from '@/components/workspace/WorkspaceSwitcher';
 import Link from 'next/link';
 import clsx from 'clsx';
@@ -35,29 +36,17 @@ export default function Sidebar() {
       {expanded && <WorkspaceSwitcher />}
 
       {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto py-4">
-        <ul className="space-y-1 px-3">
-          {nav.map(item => (
-            <li key={item.href}>
-              <Link
-                href={item.href}
-                className={clsx(
-                  "group flex items-center rounded-lg p-3 text-sm font-medium transition-all duration-200",
-                  "hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-gray-700",
-                  "text-gray-700 dark:text-gray-300"
-                )}
-              >
-                <item.icon className="h-5 w-5 flex-shrink-0" />
-                {expanded && (
-                  <span className="ml-3 transition-opacity duration-200">
-                    {item.label}
-                  </span>
-                )}
-              </Link>
-            </li>
-          ))}
-        </ul>
-
+      <nav className="flex-1 overflow-y-auto py-4 px-3">
+        <SubNav
+          items={nav.map(n => ({
+            href: n.href,
+            label: n.label,
+            icon: <n.icon className="h-5 w-5" />
+          }))}
+          orientation="vertical"
+          collapsed={!expanded}
+          className="w-full"
+        />
       </nav>
 
       {/* Footer */}

--- a/packages/ui/src/components/layout/SubNav/SubNav.css
+++ b/packages/ui/src/components/layout/SubNav/SubNav.css
@@ -1,0 +1,6 @@
+.subnav-link {
+  @apply px-3 py-2 text-sm font-medium text-gray-600 transition-colors border-b-2 border-transparent hover:text-indigo-600;
+}
+.subnav-link-active {
+  @apply border-indigo-600 text-indigo-600;
+}

--- a/packages/ui/src/components/layout/SubNav/SubNav.tsx
+++ b/packages/ui/src/components/layout/SubNav/SubNav.tsx
@@ -1,0 +1,70 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../../next.d.ts" />
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+import clsx from 'clsx';
+import './SubNav.css';
+
+export interface SubNavItem {
+  href: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface SubNavProps {
+  items: SubNavItem[];
+  orientation?: 'horizontal' | 'vertical';
+  collapsed?: boolean;
+  className?: string;
+}
+
+export const SubNav = ({
+  items,
+  orientation = 'horizontal',
+  collapsed = false,
+  className
+}: SubNavProps) => {
+  const pathname = usePathname();
+  const params = useSearchParams();
+  return (
+    <nav
+      className={clsx(
+        orientation === 'horizontal'
+          ? 'mb-4 flex space-x-4 border-b'
+          : 'space-y-1',
+        className
+      )}
+    >
+      {items.map(item => {
+        const current = params.toString()
+          ? `${pathname}?${params.toString()}`
+          : pathname;
+        const isActive = current === item.href;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={clsx(
+              orientation === 'horizontal'
+                ? 'subnav-link'
+                : 'group flex items-center rounded-lg p-3 text-sm font-medium transition-all duration-200 hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-gray-700',
+              orientation === 'vertical' && (isActive ? 'bg-indigo-50 text-indigo-600 dark:bg-gray-700' : 'text-gray-700 dark:text-gray-300'),
+              orientation === 'horizontal' && isActive && 'subnav-link-active'
+            )}
+          >
+            {item.icon && <span className="h-5 w-5 flex-shrink-0">{item.icon}</span>}
+            {orientation === 'vertical' ? (
+              !collapsed && <span className="ml-3">{item.label}</span>
+            ) : (
+              <span>{item.label}</span>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+};
+
+SubNav.displayName = 'SubNav';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,4 +12,5 @@ export * from './IconButton';
 export * from './Dropdown';
 export * from './Modal';
 export * from './Tabs';
-export * from './Toast'; 
+export * from './Toast';
+export * from './components/layout/SubNav/SubNav';

--- a/packages/ui/src/next.d.ts
+++ b/packages/ui/src/next.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'next/link' {
+  const Link: any;
+  export default Link;
+}
+
+declare module 'next/navigation' {
+  export const usePathname: any;
+  export const useSearchParams: any;
+  export const useRouter: any;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Summary
- add new `SubNav` component in UI package
- wire SubNav into the sidebar
- swap dashboard and settings pages from Tabs to SubNav

## Testing
- `pnpm typecheck` *(fails: "command exited with code 2")*
- `pnpm validate:all` *(fails: "command exited with code 1")*

------
https://chatgpt.com/codex/tasks/task_e_685b5aacf808832293785701e46b4b46