### PR TITLE
Improve sed portability in fix scripts

### DIFF
--- a/scripts/fix-all-typescript-errors.sh
+++ b/scripts/fix-all-typescript-errors.sh
@@ -13,6 +13,15 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Helper for portable in-place sed
+sedi() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # 1. Fix missing React types in packages/ui
 echo -e "${BLUE}1. Installing React types in packages/ui...${NC}"
 cd packages/ui
@@ -62,9 +71,9 @@ cd ../..
 echo -e "${BLUE}7. Fixing Database imports...${NC}"
 find apps/web/lib -name "*.ts" -o -name "*.tsx" | while read file; do
     # Change import { Database } to import type { Database }
-    sed -i '' "s/import { Database }/import type { Database }/g" "$file" 2>/dev/null || true
+    sedi "s/import { Database }/import type { Database }/g" "$file" 2>/dev/null || true
     # Change import { type Database } to import type { Database }
-    sed -i '' "s/import { type Database }/import type { Database }/g" "$file" 2>/dev/null || true
+    sedi "s/import { type Database }/import type { Database }/g" "$file" 2>/dev/null || true
 done
 
 # 8. Clear all TypeScript caches

--- a/scripts/fix-typescript-resolution.sh
+++ b/scripts/fix-typescript-resolution.sh
@@ -12,6 +12,15 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Helper for portable in-place sed
+sedi() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # 1. Update the root tsconfig.json to include path mappings
 echo -e "${BLUE}1. Updating root tsconfig.json...${NC}"
 cat > tsconfig.json << 'EOF'
@@ -215,7 +224,7 @@ EOF
 
 # 5. Fix actions/projects.ts import
 echo -e "${BLUE}5. Fixing actions/projects.ts...${NC}"
-sed -i '' "s/import { createClient } from '@\/lib\/supabase-server';/import { supabaseServer } from '@\/lib\/supabase-server';/" apps/web/actions/projects.ts
+sedi "s/import { createClient } from '@\/lib\/supabase-server';/import { supabaseServer } from '@\/lib\/supabase-server';/" apps/web/actions/projects.ts
 
 # 6. Clear TypeScript cache
 echo -e "${BLUE}6. Clearing TypeScript cache...${NC}"


### PR DESCRIPTION
## Summary
- detect operating system in TypeScript fix scripts
- use `sed` in-place option that works on both macOS and Linux

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685b5aafe0c08322ac1bf97447e8a76f