### PR TITLE
Add workspace and projects dashboards

### DIFF
--- a/apps/web/app/(protected)/dashboards/ProjectsDashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboards/ProjectsDashboard/page.tsx
@@ -1,0 +1,47 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { ProjectCard } from '@/components/projects';
+
+interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  status: 'active' | 'completed' | 'on_hold' | 'cancelled';
+  progress: number;
+  budget: number;
+  spent: number;
+  workspace_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export default async function ProjectsDashboardPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const projects: Array<Project> = [
+    {
+      id: 'demo1',
+      workspace_id: 'demo-ws',
+      name: 'Demo Project One',
+      description: 'Sample project',
+      status: 'active',
+      progress: 0,
+      budget: 0,
+      spent: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Projects Dashboard</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {projects.map(project => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboards/WorkspaceDashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboards/WorkspaceDashboard/page.tsx
@@ -1,0 +1,25 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { KpiCard } from '@ui';
+
+export default async function WorkspaceDashboardPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const metrics = [
+    { title: 'Projects', value: '0' },
+    { title: 'Tasks', value: '0' },
+    { title: 'Team Members', value: '0' }
+  ];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Workspace Dashboard</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+        {metrics.map(metric => (
+          <KpiCard key={metric.title} title={metric.title} value={metric.value} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboards/projects/page.tsx
+++ b/apps/web/app/(protected)/dashboards/projects/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../ProjectsDashboard/page';

--- a/apps/web/app/(protected)/dashboards/workspace/page.tsx
+++ b/apps/web/app/(protected)/dashboards/workspace/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../WorkspaceDashboard/page';

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
-import { createClient } from '../lib/supabase-server';
+import { createClient } from '@/lib/supabase-server';
 
 export default async function RootPage() {
     const supabase = createClient();
@@ -11,8 +11,8 @@ export default async function RootPage() {
             // User is not authenticated, redirect to sign-in
             redirect('/sign-in');
         } else {
-            // User is authenticated, redirect to dashboard
-            redirect('/dashboard');
+            // User is authenticated, redirect to workspace dashboard
+            redirect('/dashboards/workspace');
         }
     } catch (error) {
         // If there's any error, redirect to sign-in as fallback


### PR DESCRIPTION
## Summary
- add workspace dashboard page
- add projects dashboard page
- alias routes for `/dashboards/workspace` and `/dashboards/projects`
- redirect root page to workspace dashboard

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685b5acc74f083229d15fa50e391641e