### PR TITLE
Add dashboards and route updates

### DIFF
--- a/apps/web/actions/events.ts
+++ b/apps/web/actions/events.ts
@@ -84,7 +84,7 @@ export async function createEvent(data: Omit<EventInsert, 'id' | 'created_at' | 
     }
     
     revalidatePath('/calendar');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { event, error: null };
   } catch (error) {
@@ -113,7 +113,7 @@ export async function updateEvent(id: string, data: EventUpdate) {
     }
     
     revalidatePath('/calendar');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { event, error: null };
   } catch (error) {
@@ -137,7 +137,7 @@ export async function deleteEvent(id: string) {
     }
     
     revalidatePath('/calendar');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { error: null };
   } catch (error) {
@@ -239,7 +239,7 @@ export async function markEventAsRecorded(id: string) {
     }
     
     revalidatePath('/calendar');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { event, error: null };
   } catch (error) {

--- a/apps/web/actions/projects.ts
+++ b/apps/web/actions/projects.ts
@@ -75,7 +75,7 @@ export async function createProject(data: Omit<ProjectInsert, 'id' | 'created_at
       return { project: null, error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     
     return { project, error: null };
@@ -104,7 +104,7 @@ export async function updateProject(id: string, data: ProjectUpdate) {
       return { project: null, error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     revalidatePath(`/projects/${id}`);
     
@@ -129,7 +129,7 @@ export async function deleteProject(id: string) {
       return { error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     
     return { error: null };

--- a/apps/web/actions/tasks.ts
+++ b/apps/web/actions/tasks.ts
@@ -89,7 +89,7 @@ export async function createTask(data: Omit<TaskInsert, 'id' | 'created_at' | 'u
       return { task: null, error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     if (data.project_id) {
       revalidatePath(`/projects/${data.project_id}`);
@@ -125,7 +125,7 @@ export async function updateTask(id: string, data: TaskUpdate) {
       return { task: null, error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     if (task.project_id) {
       revalidatePath(`/projects/${task.project_id}`);
@@ -159,7 +159,7 @@ export async function deleteTask(id: string) {
       return { error: error.message };
     }
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     if (taskInfo?.project_id) {
       revalidatePath(`/projects/${taskInfo.project_id}`);
@@ -241,7 +241,7 @@ export async function createSubtasks(parentTaskId: string, subtasks: Array<Omit<
       .eq('id', parentTaskId)
       .single();
     
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/projects');
     revalidatePath('/projects');
     if (parentTask?.project_id) {
       revalidatePath(`/projects/${parentTask.project_id}`);

--- a/apps/web/actions/workspace.ts
+++ b/apps/web/actions/workspace.ts
@@ -82,7 +82,7 @@ export async function createWorkspace(data: Omit<WorkspaceInsert, 'id'>, ownerId
     }
     
     revalidatePath('/workspace-selection');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { workspace, error: null };
   } catch (error) {
@@ -405,7 +405,7 @@ export async function joinWorkspaceByCode(identifier: string, userId: string) {
     }
     
     revalidatePath('/workspace-selection');
-    revalidatePath('/dashboard');
+    revalidatePath('/dashboards/workspace');
     
     return { workspace, error: null };
   } catch (error) {

--- a/apps/web/app/(protected)/dashboards/ProjectsDashboard.tsx
+++ b/apps/web/app/(protected)/dashboards/ProjectsDashboard.tsx
@@ -1,0 +1,8 @@
+export default function ProjectsDashboard() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Projects Dashboard</h1>
+      <p className="text-gray-600">Manage and track your projects here.</p>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboards/WorkspaceDashboard.tsx
+++ b/apps/web/app/(protected)/dashboards/WorkspaceDashboard.tsx
@@ -1,0 +1,8 @@
+export default function WorkspaceDashboard() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Workspace Dashboard</h1>
+      <p className="text-gray-600">Overview of your workspace activity.</p>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboards/projects/page.tsx
+++ b/apps/web/app/(protected)/dashboards/projects/page.tsx
@@ -1,0 +1,5 @@
+import ProjectsDashboard from '../ProjectsDashboard';
+
+export default function ProjectsDashboardPage() {
+  return <ProjectsDashboard />;
+}

--- a/apps/web/app/(protected)/dashboards/workspace/page.tsx
+++ b/apps/web/app/(protected)/dashboards/workspace/page.tsx
@@ -1,0 +1,5 @@
+import WorkspaceDashboard from '../WorkspaceDashboard';
+
+export default function WorkspaceDashboardPage() {
+  return <WorkspaceDashboard />;
+}

--- a/apps/web/app/(protected)/projects/[id]/page.tsx
+++ b/apps/web/app/(protected)/projects/[id]/page.tsx
@@ -27,7 +27,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
   return (
     <div className="space-y-8">
       <Link
-        href="/dashboard"
+        href="/dashboards/projects"
         className="inline-flex items-center text-sm text-indigo-600 hover:underline"
       >
         <ArrowLeft className="mr-1 h-4 w-4" /> Back

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,8 +11,8 @@ export default async function RootPage() {
             // User is not authenticated, redirect to sign-in
             redirect('/sign-in');
         } else {
-            // User is authenticated, redirect to dashboard
-            redirect('/dashboard');
+            // User is authenticated, redirect to workspace dashboard
+            redirect('/dashboards/workspace');
         }
     } catch (error) {
         // If there's any error, redirect to sign-in as fallback

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import clsx from 'clsx';
 
 const nav = [
-  { href: '/dashboard' as const, label: 'Projects', icon: Folder },
+  { href: '/dashboards/projects' as const, label: 'Projects', icon: Folder },
   { href: '/directory' as const, label: 'Directory', icon: Users },
   { href: '/calendar' as const, label: 'Calendar', icon: Calendar },
   { href: '/messages' as const, label: 'Messages', icon: MessageSquare }
@@ -27,7 +27,7 @@ export default function Sidebar() {
     >
       {/* Header */}
       <div className="flex h-16 items-center border-b px-4">
-        <Link href="/dashboard" className="text-xl font-bold text-indigo-600">
+        <Link href="/dashboards/workspace" className="text-xl font-bold text-indigo-600">
           {expanded ? 'Stratus' : 'S'}
         </Link>
       </div>

--- a/apps/web/components/workspace/WorkspaceSelection.tsx
+++ b/apps/web/components/workspace/WorkspaceSelection.tsx
@@ -59,7 +59,7 @@ export function WorkspaceSelection({ userId, initialWorkspaces, initialInvitatio
   const handleWorkspaceSelect = (workspace: Workspace) => {
     // Set current workspace in local storage for session persistence
     localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
-    router.push('/dashboard');
+    router.push('/dashboards/workspace');
   };
 
   const handleCreateWorkspace = async () => {


### PR DESCRIPTION
## Summary
- add Workspace and Projects dashboards
- add routing for new dashboard pages
- redirect authenticated users to the workspace dashboard
- update sidebar and workspace selection links
- revalidate new dashboard paths in actions

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b6620c2408322af4132f6be8fd611