### PR TITLE
Update db package path to @mad/db

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -3,7 +3,7 @@
 ## Project Structure
 This is a pnpm workspace monorepo with the following structure:
 - `/apps/*` - Application packages (Next.js web app, docs)
-- `/packages/*` - Shared packages (@ui, @db)
+- `/packages/*` - Shared packages (@ui, @mad/db)
 - Root configuration files for Turbo, pnpm, and TypeScript
 
 ## Import Rules
@@ -38,8 +38,8 @@ In `apps/web/tsconfig.json`, ensure ALL workspace packages are mapped:
       "@/*": ["./*"],
       "@ui": ["../../packages/ui/src/index.ts"],
       "@ui/*": ["../../packages/ui/src/*"],
-      "@db": ["../../packages/db/src/index.ts"],
-      "@db/*": ["../../packages/db/src/*"]
+      "@mad/db": ["../../packages/db/src/index.ts"],
+      "@mad/db/*": ["../../packages/db/src/*"]
     }
   }
 }
@@ -57,8 +57,8 @@ For packages meant to be consumed by Next.js with transpilePackages:
 
 For packages that need to be built:
 ```json
-{
-  "name": "@db",
+{ 
+  "name": "@mad/db",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -73,7 +73,7 @@ For packages that need to be built:
 In `next.config.js`, list all workspace packages:
 ```javascript
 const nextConfig = {
-  transpilePackages: ['@ui', '@db'],
+  transpilePackages: ['@ui', '@mad/db'],
   // ... other config
 };
 ```
@@ -127,13 +127,13 @@ import { Button, Card } from '@ui';
 ### ❌ DON'T: Import from dist in development
 ```typescript
 // Wrong
-import { createClient } from '@db/dist/client';
+import { createClient } from '@mad/db/dist/client';
 ```
 
 ### ✅ DO: Import from source
 ```typescript
 // Correct
-import { createClient } from '@db';
+import { createClient } from '@mad/db';
 ```
 
 ## File Creation Rules
@@ -143,10 +143,10 @@ import { createClient } from '@db';
 2. Export from index: Add `export * from './NewComponent';` to `packages/ui/src/index.ts`
 3. Import in apps: `import { NewComponent } from '@ui';`
 
-### When creating new utilities in @db:
+### When creating new utilities in @mad/db:
 1. Create utility file: `packages/db/src/newUtility.ts`
 2. Export from index: Add `export * from './newUtility';` to `packages/db/src/index.ts`
-3. Import in apps: `import { newUtility } from '@db';`
+3. Import in apps: `import { newUtility } from '@mad/db';`
 
 ## Pre-Deployment Checklist
 
@@ -177,7 +177,7 @@ Before pushing code that will be deployed:
 ## AI Assistant Instructions
 
 When generating code for this monorepo:
-1. Always use root-level imports from packages (@ui, @db)
+1. Always use root-level imports from packages (@ui, @mad/db)
 2. Never suggest subpath imports like @ui/Button
 3. When creating new components, always update the package's index.ts
 4. Ensure TypeScript paths are configured for any new packages

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,10 +20,10 @@ if [ -n "$STAGED_FILES" ]; then
       IMPORT_ERRORS=$((IMPORT_ERRORS + 1))
     fi
     
-    # Check for @db subpath imports (excluding types)
-    if grep -E "from ['\"]@db/" "$file" 2>/dev/null | grep -v "from ['\"]@db/types"; then
-      echo "❌ Error: Found @db subpath import in $file"
-      echo "   Change to: import { function } from '@db';"
+    # Check for @mad/db subpath imports (excluding types)
+    if grep -E "from ['\"]@mad/db/" "$file" 2>/dev/null | grep -v "from ['\"]@mad/db/types"; then
+      echo "❌ Error: Found @mad/db subpath import in $file"
+      echo "   Change to: import { function } from '@mad/db';"
       IMPORT_ERRORS=$((IMPORT_ERRORS + 1))
     fi
     
@@ -39,7 +39,7 @@ if [ -n "$STAGED_FILES" ]; then
     echo ""
     echo "💡 To fix automatically, run:"
     echo "   sed -i '' \"s/from '@ui\\/[^']*'/from '@ui'/g\" $STAGED_FILES"
-    echo "   sed -i '' \"s/from '@db\\/[^']*'/from '@db'/g\" $STAGED_FILES"
+    echo "   sed -i '' \"s/from '@mad\/db\\/[^']*'/from '@mad/db'/g\" $STAGED_FILES"
     exit 1
   fi
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,26 +22,26 @@ mad-monorepo/
 ```typescript
 // ✅ CORRECT - Always import from package root
 import { Button, Card, Input } from '@ui';
-import { createClient, Project } from '@db';
+import { createClient, Project } from '@mad/db';
 
 // ❌ WRONG - Never use subpath imports
 import { Button } from '@ui/Button';
-import { createClient } from '@db/client';
+import { createClient } from '@mad/db/client';
 ```
 
 ### 2. **Package Resolution**
 - `@ui` → `packages/ui/src/index.ts` (transpiled by Next.js)
-- `@db` → `packages/db/src/index.ts` (requires build)
+- `@mad/db` → `packages/db/src/index.ts` (requires build)
 - Always export new components from package index files
 
 ### 3. **Type Safety**
 ```typescript
 // Always use type imports for types
-import type { Database } from '@db';
+import type { Database } from '@mad/db';
 import type { FC, ReactNode } from 'react';
 
 // Never import runtime values as types
-import { Database } from '@db'; // ❌ Wrong if Database is a type
+import { Database } from '@mad/db'; // ❌ Wrong if Database is a type
 ```
 
 ## 🛠️ Development Workflow
@@ -66,7 +66,7 @@ import { Database } from '@db'; // ❌ Wrong if Database is a type
 1. Create: packages/db/src/newFeature.ts
 2. Export: Add to packages/db/src/index.ts
 3. Build: cd packages/db && pnpm build
-4. Import: import { newFeature } from '@db';
+4. Import: import { newFeature } from '@mad/db';
 ```
 
 #### New Page/Route
@@ -86,7 +86,7 @@ import { Database } from '@db'; // ❌ Wrong if Database is a type
 # Restart dev server
 ```
 
-#### "Cannot find module '@db'"
+#### "Cannot find module '@mad/db'"
 ```bash
 cd packages/db && pnpm build
 # Check if types.ts exports Database type
@@ -175,7 +175,7 @@ import { supabaseAdmin } from '@/lib/supabase-admin';
 
 ### Type-Safe Queries
 ```typescript
-import type { Database } from '@db';
+import type { Database } from '@mad/db';
 
 type Project = Database['public']['Tables']['projects']['Row'];
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@ui', '@db'],
+  transpilePackages: ['@ui', '@mad/db'],
   experimental: {
     typedRoutes: true
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate": "pnpm validate:all",
     "fix:imports": "pnpm fix:imports:ui && pnpm fix:imports:db",
     "fix:imports:ui": "find . -name '*.ts' -o -name '*.tsx' | xargs sed -i '' \"s/from '@ui\\/[^']*'/from '@ui'/g\"",
-    "fix:imports:db": "find . -name '*.ts' -o -name '*.tsx' | xargs sed -i '' \"s/from '@db\\/[^']*'/from '@db'/g\"",
+    "fix:imports:db": "find . -name '*.ts' -o -name '*.tsx' | xargs sed -i '' \"s/from '@mad\/db\\/[^']*'/from '@mad/db'/g\"",
     "prevalidate:deploy": "pnpm validate:all",
     "preinstall": "npx only-allow pnpm",
     "setup": "./scripts/setup.sh"

--- a/scripts/check-files.sh
+++ b/scripts/check-files.sh
@@ -56,11 +56,11 @@ done
 echo ""
 echo "Summary: $MISSING_COUNT files missing"
 
-# Check if dist directory exists for @db
+# Check if dist directory exists for @mad/db
 if [ -d "packages/db/dist" ]; then
-    echo -e "${GREEN}✅ @db package is built${NC}"
+    echo -e "${GREEN}✅ @mad/db package is built${NC}"
 else
-    echo -e "${YELLOW}⚠️  @db package needs to be built${NC}"
+    echo -e "${YELLOW}⚠️  @mad/db package needs to be built${NC}"
 fi
 
 # Check current directory structure

--- a/scripts/fix-all-typescript-errors.sh
+++ b/scripts/fix-all-typescript-errors.sh
@@ -31,8 +31,8 @@ cd apps/docs
 pnpm add -D storybook@^8.6.14
 cd ../..
 
-# 4. Fix the @db package exports properly
-echo -e "${BLUE}4. Fixing @db package exports...${NC}"
+# 4. Fix the @mad/db package exports properly
+echo -e "${BLUE}4. Fixing @mad/db package exports...${NC}"
 cat > packages/db/src/index.ts << 'EOF'
 // Export everything from modules
 export * from './client';
@@ -53,12 +53,12 @@ if ! grep -q "export type { Database }" packages/db/types.ts && ! grep -q "expor
 fi
 
 # 6. Build the db package
-echo -e "${BLUE}6. Building @db package...${NC}"
+echo -e "${BLUE}6. Building @mad/db package...${NC}"
 cd packages/db
 pnpm build
 cd ../..
 
-# 7. Fix all @db imports to use proper type imports
+# 7. Fix all @mad/db imports to use proper type imports
 echo -e "${BLUE}7. Fixing Database imports...${NC}"
 find apps/web/lib -name "*.ts" -o -name "*.tsx" | while read file; do
     # Change import { Database } to import type { Database }

--- a/scripts/fix-typescript-comprehensive.sh
+++ b/scripts/fix-typescript-comprehensive.sh
@@ -14,17 +14,17 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# 1. Fix @db package exports and types
-echo -e "${BLUE}1. Fixing @db package exports...${NC}"
+# 1. Fix @mad/db package exports and types
+echo -e "${BLUE}1. Fixing @mad/db package exports...${NC}"
 
-# Update @db index.ts to properly export types
+# Update @mad/db index.ts to properly export types
 cat > packages/db/src/index.ts << 'EOF'
 export * from './client';
 export * from './project';
 export { type Database } from '../types';
 EOF
 
-echo -e "${GREEN}✅ Fixed @db exports${NC}"
+echo -e "${GREEN}✅ Fixed @mad/db exports${NC}"
 
 # 2. Install missing type dependencies
 echo -e "${BLUE}2. Installing missing type dependencies...${NC}"
@@ -51,7 +51,7 @@ if [ -f "apps/web/lib/supabase-server.ts" ]; then
     cat > apps/web/lib/supabase-server.ts << 'EOF'
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
-import type { Database } from '@db'
+import type { Database } from '@mad/db'
 
 export const createClient = () => {
   const cookieStore = cookies()
@@ -101,9 +101,9 @@ find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xar
 # Fix @ui subpath imports
 find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xargs sed -i '' "s/from '@ui\/[^']*'/from '@ui'/g"
 
-# Fix @db subpath imports (except types)
-find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xargs sed -i '' "s/from '@db\/client'/from '@db'/g"
-find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xargs sed -i '' "s/from '@db\/project'/from '@db'/g"
+# Fix @mad/db subpath imports (except types)
+find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xargs sed -i '' "s/from '@mad\/db\/client'/from '@mad/db'/g"
+find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -v dist | xargs sed -i '' "s/from '@mad\/db\/project'/from '@mad/db'/g"
 
 echo -e "${GREEN}✅ Fixed import statements${NC}"
 
@@ -121,7 +121,7 @@ echo -e "${GREEN}✅ Fixed component prop types${NC}"
 # 6. Build packages in correct order
 echo -e "${BLUE}6. Building packages...${NC}"
 
-# Build @db package first (it's needed by others)
+# Build @mad/db package first (it's needed by others)
 cd packages/db
 pnpm build
 cd ../..

--- a/scripts/fix-typescript-resolution.sh
+++ b/scripts/fix-typescript-resolution.sh
@@ -31,8 +31,8 @@ cat > tsconfig.json << 'EOF'
     "paths": {
       "@ui": ["packages/ui/src/index.ts"],
       "@ui/*": ["packages/ui/src/*"],
-      "@db": ["packages/db/src/index.ts"],
-      "@db/*": ["packages/db/src/*"]
+      "@mad/db": ["packages/db/src/index.ts"],
+      "@mad/db/*": ["packages/db/src/*"]
     }
   },
   "include": ["apps", "packages", "config"],
@@ -64,8 +64,8 @@ cat > apps/web/tsconfig.json << 'EOF'
       "@/*": ["./*"],
       "@ui": ["../../packages/ui/src/index.ts"],
       "@ui/*": ["../../packages/ui/src/*"],
-      "@db": ["../../packages/db/src/index.ts"],
-      "@db/*": ["../../packages/db/src/*"]
+      "@mad/db": ["../../packages/db/src/index.ts"],
+      "@mad/db/*": ["../../packages/db/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/scripts/validate-deploy.sh
+++ b/scripts/validate-deploy.sh
@@ -28,13 +28,13 @@ fi
 # 2. Build validation - focus on web app and packages
 echo -e "${BLUE}2. Testing package builds...${NC}"
 
-# Build @db package
+# Build @mad/db package
 cd packages/db
 if ! pnpm build; then
-    echo -e "${RED}❌ @db package build failed${NC}"
+    echo -e "${RED}❌ @mad/db package build failed${NC}"
     ERRORS=$((ERRORS + 1))
 else
-    echo -e "${GREEN}✅ @db package build passed${NC}"
+    echo -e "${GREEN}✅ @mad/db package build passed${NC}"
 fi
 cd ../..
 
@@ -80,7 +80,7 @@ if [ $ERRORS -eq 0 ]; then
     echo -e "${GREEN}✅ Ready for deployment${NC}"
     echo ""
     echo "✅ Import validation: PASSED"
-    echo "✅ @db package build: PASSED" 
+    echo "✅ @mad/db package build: PASSED"
     echo "✅ Web app build: PASSED"
     echo "✅ Web app TypeScript: PASSED"
     echo "✅ Web app linting: PASSED"

--- a/scripts/validate-imports.sh
+++ b/scripts/validate-imports.sh
@@ -25,14 +25,14 @@ else
     echo -e "${GREEN}✅ No @ui subpath imports found${NC}"
 fi
 
-# Check for subpath imports from @db
-echo "Checking for @db subpath imports..."
-if grep -r "from '@db/" apps/web --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "from '@db/types'"; then
-    echo -e "${RED}❌ Found subpath imports from @db package${NC}"
-    echo "These should be changed to: import { function } from '@db';"
+# Check for subpath imports from @mad/db
+echo "Checking for @mad/db subpath imports..."
+if grep -r "from '@mad/db/" apps/web --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "from '@mad/db/types'"; then
+    echo -e "${RED}❌ Found subpath imports from @mad/db package${NC}"
+    echo "These should be changed to: import { function } from '@mad/db';"
     ERRORS=$((ERRORS + 1))
 else
-    echo -e "${GREEN}✅ No @db subpath imports found${NC}"
+    echo -e "${GREEN}✅ No @mad/db subpath imports found${NC}"
 fi
 
 # Check for dist folder imports
@@ -63,11 +63,11 @@ else
     echo -e "${GREEN}✅ @ui found in transpilePackages${NC}"
 fi
 
-if ! grep -q "transpilePackages.*@db" apps/web/next.config.js; then
-    echo -e "${RED}❌ @db not found in transpilePackages${NC}"
+if ! grep -q "transpilePackages.*@mad/db" apps/web/next.config.js; then
+    echo -e "${RED}❌ @mad/db not found in transpilePackages${NC}"
     ERRORS=$((ERRORS + 1))
 else
-    echo -e "${GREEN}✅ @db found in transpilePackages${NC}"
+    echo -e "${GREEN}✅ @mad/db found in transpilePackages${NC}"
 fi
 
 # Check tsconfig paths

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -24,8 +24,8 @@ describe('@mad/db package', () => {
   });
 
   it('should export Project type', () => {
-    // @ts-expect-error: This test intentionally checks that the Project type is exported from @db and can be assigned, even though this is not a runtime value.
-    const project: import('@db').Project = {
+    // @ts-expect-error: This test intentionally checks that the Project type is exported from @mad/db and can be assigned, even though this is not a runtime value.
+    const project: import('@mad/db').Project = {
       id: 'test-id',
       workspace_id: 'workspace-id',
       name: 'Test Project',


### PR DESCRIPTION
## Summary
- use `@mad/db` package path in Next.js config
- update AGENTS instructions and docs
- switch references in code and scripts to `@mad/db`

## Testing
- `pnpm validate:all` *(fails: Module 'next/navigation' has no exported member 'redirect')*

------
https://chatgpt.com/codex/tasks/task_e_685b6b675d988322952f19fc0af4e65e