### PR TITLE
Implement workspace deletion action

### DIFF
--- a/apps/web/actions/workspace.ts
+++ b/apps/web/actions/workspace.ts
@@ -477,4 +477,31 @@ export async function createInvitationCode(workspaceId: string) {
     console.error('Error in createInvitationCode:', error);
     return { code: null, error: 'Failed to create invitation code' };
   }
-} 
+}
+
+export async function deleteWorkspace(id: string) {
+  const supabase = createClient();
+
+  try {
+    // Remove all team members associated with the workspace
+    await supabase.from('team_members').delete().eq('workspace_id', id);
+
+    const { error } = await supabase
+      .from('workspaces')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      console.error('Error deleting workspace:', error);
+      return { error: error.message };
+    }
+
+    revalidatePath('/workspace-selection');
+    revalidatePath('/dashboard');
+
+    return { error: null };
+  } catch (error) {
+    console.error('Error in deleteWorkspace:', error);
+    return { error: 'Failed to delete workspace' };
+  }
+}

--- a/apps/web/components/settings/SettingsTabs.tsx
+++ b/apps/web/components/settings/SettingsTabs.tsx
@@ -5,9 +5,14 @@ import { useTheme } from 'next-themes';
 import { Card, Button, Input, Select, Toggle, Badge, Modal, Toast, SubNav } from '@ui';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { Shield, CreditCard, AlertTriangle, Settings, Users, Key, Clock, Bell } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { deleteWorkspace } from '@/actions/workspace';
+import { useWorkspaces } from '@/contexts/AppContext';
 
 export function SettingsTabs() {
     const { theme, setTheme } = useTheme();
+    const router = useRouter();
+    const { currentWorkspace } = useWorkspaces();
     
     const [settings, setSettings] = useState({
         workspaceName: 'My Workspace',
@@ -78,19 +83,19 @@ export function SettingsTabs() {
     };
 
     const handleDeleteWorkspace = async () => {
-        if (deleteConfirmation === 'DELETE') {
+        if (deleteConfirmation === 'DELETE' && currentWorkspace) {
             setLoading(true);
             try {
-                await new Promise(resolve => setTimeout(resolve, 2000));
-                console.log('Deleting workspace...');
-                // TODO: Implement delete functionality
-                showNotification('Workspace deleted successfully!');
-                setShowDeleteWorkspace(false);
-                setDeleteConfirmation('');
-                // Redirect to workspace selection or sign-in
-                setTimeout(() => {
-                    window.location.href = '/workspace-selection';
-                }, 1500);
+                const { error } = await deleteWorkspace(currentWorkspace.id);
+
+                if (error) {
+                    showNotification(error, 'error');
+                } else {
+                    showNotification('Workspace deleted successfully!');
+                    setShowDeleteWorkspace(false);
+                    setDeleteConfirmation('');
+                    router.push('/workspace-selection');
+                }
             } catch (error) {
                 console.error('Failed to delete workspace:', error);
                 showNotification('Failed to delete workspace. Please try again.', 'error');


### PR DESCRIPTION
## Summary
- add `deleteWorkspace` server action
- call workspace deletion in SettingsTabs with notifications and redirect

## Testing
- `pnpm validate:all` *(fails: Module '"next/navigation"' has no exported member 'redirect')*

------
https://chatgpt.com/codex/tasks/task_e_685b735d95788322903cd192b3353819