### PR TITLE
Add nav rail layout and enhance navigation components

### DIFF
--- a/apps/web/components/layout/NavRailLayout.tsx
+++ b/apps/web/components/layout/NavRailLayout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Sidebar, { type SidebarItem } from '@/components/sidebar/Sidebar';
+import { SubNav, type SubNavItem, Button } from '@ui';
+
+interface NavRailLayoutProps {
+  nav: (SidebarItem & { subItems?: SubNavItem[]; fabLabel?: string })[];
+  children: React.ReactNode;
+}
+
+export default function NavRailLayout({ nav, children }: NavRailLayoutProps) {
+  const pathname = usePathname();
+  const current = nav.find(n => pathname.startsWith(n.href)) ?? nav[0];
+
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      <Sidebar items={nav} />
+      {current?.subItems && (
+        <div className="hidden md:block w-48 border-r bg-white p-3">
+          <SubNav items={current.subItems} orientation="vertical" />
+        </div>
+      )}
+      <div className="flex-1 relative p-6 md:p-8">
+        {children}
+        {current?.fabLabel && (
+          <Button variant="primary" className="fixed bottom-6 right-6 z-20">
+            {current.fabLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -1,19 +1,28 @@
 'use client';
 import { useSidebar } from './context';
 import { Folder, Users, Calendar, MessageSquare, Settings } from 'lucide-react';
-import { SubNav } from '@ui';
+import React from 'react';
+import { SubNav, type SubNavItem } from '@ui';
 import { WorkspaceSwitcher } from '@/components/workspace/WorkspaceSwitcher';
 import Link from 'next/link';
 import clsx from 'clsx';
 
-const nav = [
-  { href: '/dashboard' as const, label: 'Projects', icon: Folder },
-  { href: '/directory' as const, label: 'Directory', icon: Users },
-  { href: '/calendar' as const, label: 'Calendar', icon: Calendar },
-  { href: '/messages' as const, label: 'Messages', icon: MessageSquare }
-] as const;
+export interface SidebarItem extends Omit<SubNavItem, 'icon'> {
+  icon: React.ComponentType<{ className?: string }>;
+}
 
-export default function Sidebar() {
+const defaultNav: SidebarItem[] = [
+  { href: '/dashboard', label: 'Projects', icon: Folder, shortcut: '1' },
+  { href: '/directory', label: 'Directory', icon: Users, shortcut: '2' },
+  { href: '/calendar', label: 'Calendar', icon: Calendar, shortcut: '3' },
+  { href: '/messages', label: 'Messages', icon: MessageSquare, shortcut: '4' }
+];
+
+export interface SidebarProps {
+  items?: SidebarItem[];
+}
+
+export default function Sidebar({ items = defaultNav }: SidebarProps) {
   const { expanded, setExpanded } = useSidebar();
 
   return (
@@ -38,13 +47,16 @@ export default function Sidebar() {
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto py-4 px-3">
         <SubNav
-          items={nav.map(n => ({
+          items={items.map(n => ({
             href: n.href,
             label: n.label,
-            icon: <n.icon className="h-5 w-5" />
+            icon: <n.icon className="h-5 w-5" />,
+            badge: n.badge,
+            shortcut: n.shortcut
           }))}
           orientation="vertical"
           collapsed={!expanded}
+          iconOnly={!expanded}
           className="w-full"
         />
       </nav>

--- a/packages/ui/src/components/layout/SubNav/SubNav.tsx
+++ b/packages/ui/src/components/layout/SubNav/SubNav.tsx
@@ -3,20 +3,25 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import clsx from 'clsx';
+import { useEffect } from 'react';
+import { Badge } from '../../../Badge';
 import './SubNav.css';
 
 export interface SubNavItem {
   href: string;
   label: string;
   icon?: React.ReactNode;
+  badge?: number;
+  shortcut?: string;
 }
 
 interface SubNavProps {
   items: SubNavItem[];
   orientation?: 'horizontal' | 'vertical';
   collapsed?: boolean;
+  iconOnly?: boolean;
   className?: string;
 }
 
@@ -24,10 +29,26 @@ export const SubNav = ({
   items,
   orientation = 'horizontal',
   collapsed = false,
+  iconOnly = false,
   className
 }: SubNavProps) => {
   const pathname = usePathname();
   const params = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && items.some(i => i.shortcut === e.key)) {
+        const item = items.find(i => i.shortcut === e.key);
+        if (item) {
+          e.preventDefault();
+          router.push(item.href);
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [items, router]);
   return (
     <nav
       className={clsx(
@@ -55,10 +76,15 @@ export const SubNav = ({
             )}
           >
             {item.icon && <span className="h-5 w-5 flex-shrink-0">{item.icon}</span>}
-            {orientation === 'vertical' ? (
+            {!iconOnly && (orientation === 'vertical' ? (
               !collapsed && <span className="ml-3">{item.label}</span>
             ) : (
               <span>{item.label}</span>
+            ))}
+            {item.badge !== undefined && item.badge > 0 && (
+              <Badge size="sm" variant="primary" className="ml-auto">
+                {item.badge}
+              </Badge>
             )}
           </Link>
         );


### PR DESCRIPTION
## Summary
- extend `SubNav` with badge, icon-only, and shortcut support
- update `Sidebar` to accept items and forward new props
- create `NavRailLayout` composed of `Sidebar` and `SubNav`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '"next/navigation"' has no exported member 'redirect')*
- `pnpm validate:all` *(fails: @apps/web#typecheck)*
- `pnpm test` *(fails: Failed to resolve import "next/link")*

------
https://chatgpt.com/codex/tasks/task_e_685b84d22db8832286bedebd6499ae92