### PR TITLE
Add Vercel analytics to web app

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@/app/globals.css';
 import { Inter } from 'next/font/google';
 import { Providers } from './providers';
+import { Analytics } from '@vercel/analytics/next';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -18,6 +19,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@ui": "workspace:*",
     "clsx": "^2.0.0",
     "lucide-react": "^0.303.0",
+    "@vercel/analytics": "latest",
     "next": "14.2.3",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",

--- a/apps/web/types/vercel-analytics.d.ts
+++ b/apps/web/types/vercel-analytics.d.ts
@@ -1,0 +1,4 @@
+declare module '@vercel/analytics/next' {
+  import type { FC } from 'react';
+  export const Analytics: FC;
+}


### PR DESCRIPTION
## Summary
- install `@vercel/analytics` dependency
- include `<Analytics />` in the main `RootLayout`
- add local type declaration for `@vercel/analytics/next`

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685ba5000d008322b03ad061542d3ebb