### PR TITLE
Integrate Vercel analytics

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import '@/app/globals.css';
 import { Inter } from 'next/font/google';
+import { Analytics } from '@/lib/analytics';
 import { Providers } from './providers';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -18,7 +19,8 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   );
-} 
+}

--- a/apps/web/lib/analytics.tsx
+++ b/apps/web/lib/analytics.tsx
@@ -1,0 +1,15 @@
+'use client';
+import Script from 'next/script';
+
+/**
+ * Lightweight integration for Vercel Analytics.
+ * Loads the Vercel analytics script on the client.
+ */
+export function Analytics() {
+  return (
+    <Script
+      src="https://vercel.live/analytics/script.js"
+      strategy="afterInteractive"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a lightweight analytics component that loads the Vercel analytics script
- use the analytics component in the main layout

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685ba998158883228d42751a6cd38a98