### PR TITLE
Update directory navigation to sidebar

### DIFF
--- a/apps/web/app/(protected)/directory/page.tsx
+++ b/apps/web/app/(protected)/directory/page.tsx
@@ -3,9 +3,15 @@ import { redirect } from 'next/navigation';
 import { DirectoryTabs } from '@/components/directory/DirectoryTabs';
 import { getTeamMembers } from '@/actions/workspace';
 
-export default async function Directory() {
+interface DirectoryPageProps {
+  searchParams: { view?: string };
+}
+
+export default async function Directory({ searchParams }: DirectoryPageProps) {
   const session = await getSession();
   if (!session) redirect('/sign-in');
+
+  const view = (searchParams.view ?? 'members') as 'members' | 'employees' | 'companies';
 
   // Get current workspace ID from session or cookies
   // For now, we'll use a hardcoded workspace ID - in production this would come from the session
@@ -95,6 +101,8 @@ export default async function Directory() {
         members={formattedMembers}
         employees={employees}
         companies={companies}
+        initialTab={view}
+        showTabs={false}
       />
     </main>
   );

--- a/apps/web/components/directory/DirectoryTabs.tsx
+++ b/apps/web/components/directory/DirectoryTabs.tsx
@@ -48,9 +48,11 @@ interface DirectoryTabsProps {
     members: Member[];
     employees: Employee[];
     companies: Company[];
+    initialTab?: 'members' | 'employees' | 'companies';
+    showTabs?: boolean;
 }
 
-export function DirectoryTabs({ workspaceId, currentUserId, members, employees, companies }: DirectoryTabsProps) {
+export function DirectoryTabs({ workspaceId, currentUserId, members, employees, companies, initialTab = 'members', showTabs = true }: DirectoryTabsProps) {
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
     const [searchQuery, setSearchQuery] = useState('');
@@ -413,12 +415,14 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
 
     return (
         <div>
-            <Tabs defaultValue="members" className="w-full">
-                <TabsList className="mb-6">
-                    <TabsTrigger value="members">Members ({members.length})</TabsTrigger>
-                    <TabsTrigger value="employees">Employees ({employees.length})</TabsTrigger>
-                    <TabsTrigger value="companies">Companies ({companies.length})</TabsTrigger>
-                </TabsList>
+            <Tabs defaultValue={initialTab} className="w-full">
+                {showTabs && (
+                    <TabsList className="mb-6">
+                        <TabsTrigger value="members">Members ({members.length})</TabsTrigger>
+                        <TabsTrigger value="employees">Employees ({employees.length})</TabsTrigger>
+                        <TabsTrigger value="companies">Companies ({companies.length})</TabsTrigger>
+                    </TabsList>
+                )}
 
                 <TabsContent value="members">
                     {tabs[0].content}

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -5,14 +5,16 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import clsx from 'clsx';
 import { WorkspaceSwitcher } from '@/components/workspace/WorkspaceSwitcher';
-import { 
-  Home, 
-  Folder, 
-  CheckCircle, 
-  Clock, 
-  MessageSquare, 
+import {
+  Home,
+  Folder,
+  CheckCircle,
+  Clock,
+  MessageSquare,
   Calendar,
-  Users
+  Users,
+  Briefcase,
+  Building
 } from 'lucide-react';
 
 export interface SidebarItem {
@@ -103,15 +105,15 @@ const navigation: SidebarItem[] = [
       { id: 'agenda', href: '/calendar?view=agenda', label: 'Agenda' }
     ]
   },
-  { 
+  {
     id: 'directory',
-    href: '/directory',
+    href: '/directory?view=members',
     label: 'Directory',
     icon: Users,
     subItems: [
-      { id: 'people', href: '/directory', label: 'People', icon: Users },
-      { id: 'teams', href: '/directory?view=teams', label: 'Teams' },
-      { id: 'companies', href: '/directory?view=companies', label: 'Companies' }
+      { id: 'members', href: '/directory?view=members', label: 'Members', icon: Users },
+      { id: 'employees', href: '/directory?view=employees', label: 'Employees', icon: Briefcase },
+      { id: 'companies', href: '/directory?view=companies', label: 'Companies', icon: Building }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- expose 'Members', 'Employees' and 'Companies' as sidebar items
- allow DirectoryTabs to be rendered without tab list
- show directory sections based on `view` query param

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bb27dba1c8322a3dff409bdad72af