### PR TITLE
Fix workspace context hydration

### DIFF
--- a/apps/web/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/web/app/(protected)/ProtectedLayoutClient.tsx
@@ -2,17 +2,68 @@
 
 import Sidebar from '@/components/sidebar/Sidebar';
 import Header from '@/components/header/Header';
+import { useEffect } from 'react';
+import { useApp } from '@/contexts/AppContext';
 
 interface ProtectedLayoutClientProps {
   user: {
+    id: string;
+    email: string;
     name: string;
     avatar_url?: string;
-    email?: string;
   };
+  initialWorkspaces: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    logo_url: string | null;
+    created_at: string;
+    updated_at: string;
+    userRole?: string;
+  }>;
+  initialCurrentWorkspace: {
+    id: string;
+    name: string;
+    slug: string;
+    logo_url: string | null;
+    created_at: string;
+    updated_at: string;
+    userRole?: string;
+  } | null;
   children: React.ReactNode;
 }
 
-export default function ProtectedLayoutClient({ user, children }: ProtectedLayoutClientProps) {
+export default function ProtectedLayoutClient({
+  user,
+  initialWorkspaces,
+  initialCurrentWorkspace,
+  children
+}: ProtectedLayoutClientProps) {
+  const { dispatch } = useApp();
+
+  useEffect(() => {
+    dispatch({ type: 'SET_USER', payload: user });
+    dispatch({ type: 'SET_WORKSPACES', payload: initialWorkspaces });
+
+    let workspace = initialCurrentWorkspace;
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('currentWorkspace');
+      if (stored) {
+        try {
+          workspace = JSON.parse(stored);
+        } catch (e) {
+          // ignore parse errors
+        }
+      }
+    }
+
+    if (workspace) {
+      dispatch({ type: 'SET_CURRENT_WORKSPACE', payload: workspace });
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
+      }
+    }
+  }, [dispatch, user, initialWorkspaces, initialCurrentWorkspace]);
   return (
     <div className="flex min-h-screen bg-gray-50">
       <Sidebar />

--- a/apps/web/components/workspace/WorkspaceSelection.tsx
+++ b/apps/web/components/workspace/WorkspaceSelection.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, Button, Avatar, Badge, Modal, Input, ToastContainer, useToast } from '@ui';
 import { createWorkspace, joinWorkspaceByCode, acceptInvitation } from '@/actions/workspace';
+import { useApp } from '@/contexts/AppContext';
 
 interface Workspace {
   id: string;
@@ -56,9 +57,14 @@ export function WorkspaceSelection({ userId, initialWorkspaces, initialInvitatio
     }
   };
 
+  const { dispatch } = useApp();
+
   const handleWorkspaceSelect = (workspace: Workspace) => {
-    // Set current workspace in local storage for session persistence
-    localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
+    dispatch({ type: 'SET_WORKSPACES', payload: workspaces });
+    dispatch({ type: 'SET_CURRENT_WORKSPACE', payload: workspace });
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
+    }
     router.push('/dashboard');
   };
 


### PR DESCRIPTION
## Summary
- fetch workspaces in protected layout
- initialize AppContext with user and workspace data
- persist current workspace in localStorage when selecting

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bb71f39d8832286f87177c987acd9