### PR TITLE
Add activity & analytics dashboard views

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { ProjectsGrid } from '@/components/projects';
 import { TaskTable } from '@/components/tasks';
 import { TaskSuggestions } from '@/components/ai/TaskSuggestions';
 import { SmartAnalytics } from '@/components/ai/SmartAnalytics';
+import { ActivityFeed } from '@/components/activity';
+import { AnalyticsDashboard } from '@/components/analytics';
 import { Plus, Download } from 'lucide-react';
 import type { Database } from '@mad/db';
 import { getProjects, createProject, getProjectStats } from '@/actions/projects';
@@ -123,7 +125,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(false);
   const searchParams = useSearchParams();
   const view = (searchParams.get('view') ?? 'overview') as
-    'overview' | 'ai-insights' | 'projects' | 'tasks';
+    'overview' | 'ai-insights' | 'projects' | 'tasks' | 'activity' | 'analytics';
   
   // Real data state
   const [projects, setProjects] = useState<Project[]>([]);
@@ -598,6 +600,18 @@ export default function DashboardPage() {
               <SmartAnalytics />
             </div>
           </div>
+        </div>
+      )}
+
+      {view === 'activity' && (
+        <div className="space-y-6">
+          <ActivityFeed activities={recentActivity} />
+        </div>
+      )}
+
+      {view === 'analytics' && (
+        <div className="space-y-6">
+          <AnalyticsDashboard />
         </div>
       )}
 

--- a/apps/web/components/activity/ActivityFeed.tsx
+++ b/apps/web/components/activity/ActivityFeed.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Card } from '@ui';
+
+export interface Activity {
+  id: string;
+  message: string;
+  timestamp: string;
+  icon?: string;
+  color?: string;
+}
+
+interface ActivityFeedProps {
+  activities: Activity[];
+  title?: string;
+}
+
+export function ActivityFeed({ activities, title = 'Recent Activity' }: ActivityFeedProps) {
+  if (!activities || activities.length === 0) {
+    return (
+      <Card className="p-6">
+        <p className="text-center text-gray-500">No recent activity.</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6">
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">{title}</h2>
+      <div className="space-y-3">
+        {activities.map((activity) => (
+          <div key={activity.id} className="flex items-start space-x-3">
+            <div className="flex-shrink-0">
+              <span className="text-lg">{activity.icon}</span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-gray-900">{activity.message}</p>
+              <p className="text-xs text-gray-500">{activity.timestamp}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/components/activity/index.ts
+++ b/apps/web/components/activity/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityFeed';

--- a/apps/web/components/analytics/AnalyticsDashboard.tsx
+++ b/apps/web/components/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { SmartAnalytics } from '@/components/ai/SmartAnalytics';
+
+export function AnalyticsDashboard() {
+  return (
+    <div className="space-y-6">
+      <SmartAnalytics />
+    </div>
+  );
+}

--- a/apps/web/components/analytics/index.ts
+++ b/apps/web/components/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from './AnalyticsDashboard';


### PR DESCRIPTION
## Summary
- add ActivityFeed component and exports
- add AnalyticsDashboard component and exports
- extend dashboard `view` union and rendering logic to handle `activity` and `analytics`
- hook up new components to dashboard page

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bbe1e37588322ab7021e79752f755