### PR TITLE
Add time tracking features

### DIFF
--- a/apps/web/actions/time.ts
+++ b/apps/web/actions/time.ts
@@ -1,0 +1,67 @@
+'use server';
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+import type { Database } from '@mad/db';
+
+type TimeEntryInsert = Database['public']['Tables']['time_entries']['Insert'];
+
+export async function createTimeEntry(
+  data: Omit<TimeEntryInsert, 'id' | 'created_at' | 'updated_at'>
+) {
+  const supabase = createClient();
+  try {
+    const { data: entry, error } = await supabase
+      .from('time_entries')
+      .insert({
+        ...data,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating time entry:', error);
+      return { entry: null, error: error.message };
+    }
+
+    revalidatePath('/time');
+    revalidatePath('/time/timesheet');
+
+    return { entry, error: null };
+  } catch (error) {
+    console.error('Error in createTimeEntry:', error);
+    return { entry: null, error: 'Failed to create time entry' };
+  }
+}
+
+export async function getTimeEntries(workspaceId?: string, userId?: string) {
+  const supabase = createClient();
+  try {
+    let query = supabase
+      .from('time_entries')
+      .select('*')
+      .order('start_time', { ascending: false });
+
+    if (workspaceId) {
+      query = query.eq('workspace_id', workspaceId);
+    }
+
+    if (userId) {
+      query = query.eq('user_id', userId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('Error fetching time entries:', error);
+      return { entries: [], error: error.message };
+    }
+
+    return { entries: data || [], error: null };
+  } catch (error) {
+    console.error('Error in getTimeEntries:', error);
+    return { entries: [], error: 'Failed to fetch time entries' };
+  }
+}

--- a/apps/web/app/(protected)/time/approvals/page.tsx
+++ b/apps/web/app/(protected)/time/approvals/page.tsx
@@ -1,0 +1,17 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+
+export default async function ApprovalsPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Time Approvals</h1>
+        <p className="text-gray-600 mt-1">Approve submitted time entries</p>
+      </div>
+      {/* TODO: Add approvals workflow */}
+    </main>
+  );
+}

--- a/apps/web/app/(protected)/time/page.tsx
+++ b/apps/web/app/(protected)/time/page.tsx
@@ -1,9 +1,15 @@
 import { getSession } from '@/lib/user';
 import { redirect } from 'next/navigation';
+import { TimerControls } from '@/components/time/TimerControls';
 
 export default async function TimePage() {
   const session = await getSession();
   if (!session) redirect('/sign-in');
+
+  const workspaceId =
+    (session.user.user_metadata as { current_workspace_id?: string })
+      .current_workspace_id || 'default-workspace';
+  const userId = session.user.id;
 
   return (
     <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
@@ -11,7 +17,7 @@ export default async function TimePage() {
         <h1 className="text-3xl font-bold text-gray-900">Time</h1>
         <p className="text-gray-600 mt-1">Track and review time entries</p>
       </div>
-      {/* TODO: Add time tracking UI */}
+      <TimerControls workspaceId={workspaceId} userId={userId} />
     </main>
   );
 }

--- a/apps/web/app/(protected)/time/reports/page.tsx
+++ b/apps/web/app/(protected)/time/reports/page.tsx
@@ -1,0 +1,17 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+
+export default async function ReportsPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Time Reports</h1>
+        <p className="text-gray-600 mt-1">View detailed time tracking reports</p>
+      </div>
+      {/* TODO: Add reports UI */}
+    </main>
+  );
+}

--- a/apps/web/app/(protected)/time/timesheet/page.tsx
+++ b/apps/web/app/(protected)/time/timesheet/page.tsx
@@ -1,0 +1,17 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+
+export default async function TimesheetPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Timesheet</h1>
+        <p className="text-gray-600 mt-1">Review and edit logged time</p>
+      </div>
+      {/* TODO: Add timesheet table */}
+    </main>
+  );
+}

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -79,7 +79,8 @@ const navigation: SidebarItem[] = [
     subItems: [
       { id: 'timer', href: '/time', label: 'Timer', icon: Clock },
       { id: 'timesheet', href: '/time/timesheet', label: 'Timesheet' },
-      { id: 'reports', href: '/time/reports', label: 'Reports' }
+      { id: 'reports', href: '/time/reports', label: 'Reports' },
+      { id: 'approvals', href: '/time/approvals', label: 'Approvals' }
     ]
   },
   { 

--- a/apps/web/components/time/TimerControls.tsx
+++ b/apps/web/components/time/TimerControls.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button, Input, Textarea } from '@ui';
+import { createTimeEntry } from '@/actions/time';
+
+interface TimerControlsProps {
+  workspaceId: string;
+  userId: string;
+}
+
+export function TimerControls({ workspaceId, userId }: TimerControlsProps) {
+  const [running, setRunning] = useState(false);
+  const [startTime, setStartTime] = useState<Date | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [manualStart, setManualStart] = useState('');
+  const [manualEnd, setManualEnd] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (running && startTime) {
+      interval = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - startTime.getTime()) / 1000));
+      }, 1000);
+    }
+    return () => clearInterval(interval);
+  }, [running, startTime]);
+
+  const formatElapsed = (seconds: number) => {
+    const h = Math.floor(seconds / 3600)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor((seconds % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${h}:${m}:${s}`;
+  };
+
+  const handleStart = () => {
+    setRunning(true);
+    setStartTime(new Date());
+    setElapsed(0);
+  };
+
+  const handleStop = async () => {
+    if (!startTime) return;
+    const end = new Date();
+    const duration = Math.round((end.getTime() - startTime.getTime()) / 60000);
+    setRunning(false);
+    setStartTime(null);
+    setElapsed(0);
+    await createTimeEntry({
+      workspace_id: workspaceId,
+      user_id: userId,
+      description: description || null,
+      start_time: startTime.toISOString(),
+      end_time: end.toISOString(),
+      duration_minutes: duration,
+    });
+    setDescription('');
+  };
+
+  const handleManual = async () => {
+    if (!manualStart || !manualEnd) return;
+    const start = new Date(manualStart);
+    const end = new Date(manualEnd);
+    const duration = Math.round((end.getTime() - start.getTime()) / 60000);
+    await createTimeEntry({
+      workspace_id: workspaceId,
+      user_id: userId,
+      description: description || null,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      duration_minutes: duration,
+    });
+    setManualStart('');
+    setManualEnd('');
+    setDescription('');
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-4">
+        <Button variant="primary" onClick={running ? handleStop : handleStart}>
+          {running ? 'Stop' : 'Start'}
+        </Button>
+        <span className="text-xl font-mono">{formatElapsed(elapsed)}</span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Input
+          type="datetime-local"
+          label="Start"
+          value={manualStart}
+          onChange={e => setManualStart(e.target.value)}
+        />
+        <Input
+          type="datetime-local"
+          label="End"
+          value={manualEnd}
+          onChange={e => setManualEnd(e.target.value)}
+        />
+        <div className="md:col-span-2">
+          <Textarea
+            label="Description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+        </div>
+      </div>
+      <Button variant="secondary" onClick={handleManual} disabled={!manualStart || !manualEnd}>
+        Add Entry
+      </Button>
+    </div>
+  );
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,4 +2,5 @@ export * from './client';
 import { supabaseClient } from './client';
 export const createClient = () => supabaseClient;
 export * from './project';
+export * from './time';
 export type { Database } from '../types';

--- a/packages/db/src/time.ts
+++ b/packages/db/src/time.ts
@@ -1,0 +1,36 @@
+import { supabaseClient } from './client';
+import { z } from 'zod';
+import type { Database } from '../types';
+
+export type TimeEntry = Database['public']['Tables']['time_entries']['Row'];
+
+const createTimeEntrySchema = z.object({
+  workspace_id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  description: z.string().optional().nullable(),
+  start_time: z.string(),
+  end_time: z.string(),
+  duration_minutes: z.number(),
+});
+
+export async function createTimeEntry(input: z.infer<typeof createTimeEntrySchema>) {
+  const data = createTimeEntrySchema.parse(input);
+  const { data: entry, error } = await supabaseClient
+    .from('time_entries')
+    .insert({ ...data })
+    .select()
+    .single();
+  if (error) throw error;
+  return entry;
+}
+
+export async function listTimeEntries(workspaceId: string, userId: string) {
+  const { data, error } = await supabaseClient
+    .from('time_entries')
+    .select('*')
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', userId)
+    .order('start_time', { ascending: false });
+  if (error) throw error;
+  return data as TimeEntry[];
+}

--- a/packages/db/types.ts
+++ b/packages/db/types.ts
@@ -273,6 +273,29 @@ export interface Database {
         };
         Update: Partial<Database['public']['Tables']['transactions']['Row']>;
       };
+      time_entries: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          user_id: string;
+          description: string | null;
+          start_time: string;
+          end_time: string;
+          duration_minutes: number;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          workspace_id: string;
+          user_id: string;
+          description?: string | null;
+          start_time: string;
+          end_time: string;
+          duration_minutes: number;
+        };
+        Update: Partial<Database['public']['Tables']['time_entries']['Row']>;
+      };
       workspace_roles: {
         Row: {
           id: string;


### PR DESCRIPTION
## Summary
- implement TimerControls with manual entry and start/stop timer
- create server actions for time entries
- update time page to use TimerControls
- add timesheet, reports and approvals pages
- add time entry table types and export helpers
- update sidebar with Approvals link

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bbe1c0a0c8322ad3e78508f6569db