### PR TITLE
Add Event Modal for calendar

### DIFF
--- a/apps/web/app/(protected)/calendar/page.tsx
+++ b/apps/web/app/(protected)/calendar/page.tsx
@@ -131,11 +131,17 @@ export default function CalendarPage() {
     console.log('Deleted event:', eventId);
   };
 
+  const handleEventUpdate = (updated: Event) => {
+    setEvents(prev => prev.map(e => (e.id === updated.id ? updated : e)));
+    console.log('Updated event:', updated);
+  };
+
   return (
     <CalendarView
       events={events}
       onEventCreate={handleEventCreate}
       onEventDelete={handleEventDelete}
+      onEventUpdate={handleEventUpdate}
     />
   );
-} 
+}

--- a/apps/web/components/ModalManager.tsx
+++ b/apps/web/components/ModalManager.tsx
@@ -2,11 +2,11 @@
 
 import { useModal } from '@/contexts/AppContext';
 import { Modal } from '@ui';
+import { EventModal, type EventModalProps } from './modals/EventModal';
 
 // Import future modal components here
 // import { ProjectModal } from './modals/ProjectModal';
 // import { TaskModal } from './modals/TaskModal';
-// import { EventModal } from './modals/EventModal';
 
 export function ModalManager() {
     const { modal, closeModal } = useModal();
@@ -26,8 +26,7 @@ export function ModalManager() {
                 return <div>Task Modal (to be implemented)</div>;
 
             case 'event':
-                // return <EventModal {...modal.props} />;
-                return <div>Event Modal (to be implemented)</div>;
+                return <EventModal {...(modal.props as unknown as EventModalProps)} />;
 
             case 'confirmation':
                 return (

--- a/apps/web/components/calendar/CalendarView.tsx
+++ b/apps/web/components/calendar/CalendarView.tsx
@@ -25,12 +25,14 @@ interface CalendarViewProps {
     events: Event[];
     onEventCreate?: (event: Partial<Event>) => void;
     onEventDelete?: (eventId: string) => void;
+    onEventUpdate?: (event: Event) => void;
 }
 
 export function CalendarView({
     events,
     onEventCreate,
-    onEventDelete
+    onEventDelete,
+    onEventUpdate
 }: CalendarViewProps) {
     const { openModal } = useModal();
     const [currentDate, setCurrentDate] = useState(new Date());
@@ -132,6 +134,14 @@ export function CalendarView({
         setShowCreateEvent(true);
     };
 
+    const handleEventClick = (event: Event) => {
+        openModal('event', {
+            event,
+            onUpdate: (updated: Event) => onEventUpdate?.(updated),
+            onDelete: (id: string) => onEventDelete?.(id)
+        });
+    };
+
     const handleDeleteEvent = (event: Event) => {
         openModal('confirmation', {
             title: 'Delete Event',
@@ -231,8 +241,7 @@ export function CalendarView({
                                                     key={event.id}
                                                     onClick={(e) => {
                                                         e.stopPropagation();
-                                                        // TODO: Open event details modal
-                                                        console.log('Open event:', event);
+                                                        handleEventClick(event);
                                                     }}
                                                     className="text-xs bg-indigo-100 text-indigo-800 px-2 py-1 rounded truncate hover:bg-indigo-200 transition-colors"
                                                 >
@@ -282,7 +291,11 @@ export function CalendarView({
                                 {todaysEvents
                                     .sort((a, b) => a.time.localeCompare(b.time))
                                     .map((event) => (
-                                        <div key={event.id} className="p-3 bg-gray-50 rounded-lg">
+                                        <div
+                                            key={event.id}
+                                            onClick={() => handleEventClick(event)}
+                                            className="p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+                                        >
                                             <div className="flex items-start justify-between">
                                                 <div className="flex-1">
                                                     <h4 className="font-medium text-gray-900">{event.title}</h4>

--- a/apps/web/components/modals/EventModal.tsx
+++ b/apps/web/components/modals/EventModal.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import { Button, Input, Textarea, Select } from '@ui';
+import { useModal } from '@/contexts/AppContext';
+
+interface Event {
+    id: string;
+    workspace_id: string;
+    title: string;
+    description: string | null;
+    date: string;
+    time: string;
+    duration: number | null;
+    location: string | null;
+    meeting_url: string | null;
+    recorded: boolean;
+    recording_url: string | null;
+    created_by: string;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface EventModalProps {
+    event: Event;
+    onUpdate?: (event: Event) => void;
+    onDelete?: (eventId: string) => void;
+}
+
+export function EventModal({ event, onUpdate, onDelete }: EventModalProps) {
+    const { closeModal } = useModal();
+    const [editing, setEditing] = useState(false);
+    const [editedEvent, setEditedEvent] = useState({
+        title: event.title,
+        description: event.description || '',
+        date: event.date,
+        time: event.time,
+        duration: event.duration ? String(event.duration) : '',
+        location: event.location || '',
+        meeting_url: event.meeting_url || ''
+    });
+
+    const handleSave = () => {
+        const updated: Event = {
+            ...event,
+            title: editedEvent.title,
+            description: editedEvent.description || null,
+            date: editedEvent.date,
+            time: editedEvent.time,
+            duration: editedEvent.duration ? parseInt(editedEvent.duration) : null,
+            location: editedEvent.location || null,
+            meeting_url: editedEvent.meeting_url || null,
+            updated_at: new Date().toISOString()
+        };
+        onUpdate?.(updated);
+        closeModal();
+    };
+
+    const handleDelete = () => {
+        onDelete?.(event.id);
+        closeModal();
+    };
+
+    return (
+        <div className="space-y-4">
+            <Input
+                label="Event Title"
+                value={editedEvent.title}
+                onChange={(e) => setEditedEvent({ ...editedEvent, title: e.target.value })}
+                disabled={!editing}
+            />
+            <Textarea
+                label="Description"
+                value={editedEvent.description}
+                onChange={(e) => setEditedEvent({ ...editedEvent, description: e.target.value })}
+                rows={3}
+                disabled={!editing}
+            />
+            <div className="grid grid-cols-3 gap-4">
+                <Input
+                    label="Date"
+                    type="date"
+                    value={editedEvent.date}
+                    onChange={(e) => setEditedEvent({ ...editedEvent, date: e.target.value })}
+                    disabled={!editing}
+                />
+                <Input
+                    label="Time"
+                    type="time"
+                    value={editedEvent.time}
+                    onChange={(e) => setEditedEvent({ ...editedEvent, time: e.target.value })}
+                    disabled={!editing}
+                />
+                <Select
+                    label="Duration"
+                    options={[
+                        { value: '15', label: '15 minutes' },
+                        { value: '30', label: '30 minutes' },
+                        { value: '60', label: '1 hour' },
+                        { value: '90', label: '1.5 hours' },
+                        { value: '120', label: '2 hours' },
+                        { value: '240', label: '4 hours' },
+                        { value: '', label: 'All day' }
+                    ]}
+                    value={editedEvent.duration}
+                    onChange={(e) => setEditedEvent({ ...editedEvent, duration: e.target.value })}
+                    disabled={!editing}
+                />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <Input
+                    label="Location"
+                    value={editedEvent.location}
+                    onChange={(e) => setEditedEvent({ ...editedEvent, location: e.target.value })}
+                    disabled={!editing}
+                />
+                <Input
+                    label="Meeting URL"
+                    value={editedEvent.meeting_url}
+                    onChange={(e) => setEditedEvent({ ...editedEvent, meeting_url: e.target.value })}
+                    disabled={!editing}
+                />
+            </div>
+            <div className="flex justify-end space-x-3 pt-6 border-t border-gray-200">
+                {editing ? (
+                    <>
+                        <Button variant="secondary" onClick={() => { setEditing(false); setEditedEvent({
+                            title: event.title,
+                            description: event.description || '',
+                            date: event.date,
+                            time: event.time,
+                            duration: event.duration ? String(event.duration) : '',
+                            location: event.location || '',
+                            meeting_url: event.meeting_url || ''
+                        }); }}>
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="primary"
+                            onClick={handleSave}
+                            disabled={!editedEvent.title.trim() || !editedEvent.date}
+                        >
+                            Save
+                        </Button>
+                    </>
+                ) : (
+                    <>
+                        <Button variant="secondary" onClick={() => setEditing(true)}>
+                            Edit
+                        </Button>
+                        <Button variant="danger" onClick={handleDelete}>
+                            Delete
+                        </Button>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- implement `EventModal` with view/edit/delete flows
- integrate modal manager
- open modal on calendar event clicks
- handle event updates in calendar page

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bbe1f219c832297643a3c12d5d1e1