### PR TITLE
Add timesheet and report pages

### DIFF
--- a/apps/web/actions/time.ts
+++ b/apps/web/actions/time.ts
@@ -1,0 +1,76 @@
+'use server';
+
+import { createClient } from '@/lib/supabase-server';
+import type { Database } from '@mad/db';
+
+export type TimesheetEntry = Database['public']['Tables']['tasks']['Row'] & {
+  project?: Database['public']['Tables']['projects']['Row'];
+};
+
+export interface TimeReport {
+  projectId: string;
+  projectName: string;
+  totalHours: number;
+}
+
+export async function getTimesheetEntries(workspaceId: string) {
+  const supabase = createClient();
+
+  try {
+    const { data, error } = await supabase
+      .from('tasks')
+      .select(
+        `id, name, time_tracked, updated_at, project:projects(id, name, workspace_id)`
+      )
+      .eq('projects.workspace_id', workspaceId)
+      .order('updated_at', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching timesheet entries:', error);
+      return { entries: [] as TimesheetEntry[], error: error.message };
+    }
+
+    return { entries: (data as unknown as TimesheetEntry[]) || [], error: null };
+  } catch (error) {
+    console.error('Error in getTimesheetEntries:', error);
+    return { entries: [] as TimesheetEntry[], error: 'Failed to fetch timesheet entries' };
+  }
+}
+
+export async function getTimeReports(workspaceId: string) {
+  const supabase = createClient();
+
+  try {
+    const { data, error } = await supabase
+      .from('tasks')
+      .select(
+        `project_id, time_tracked, project:projects(id, name, workspace_id)`
+      )
+      .eq('projects.workspace_id', workspaceId);
+
+    if (error) {
+      console.error('Error fetching time reports:', error);
+      return { reports: [] as TimeReport[], error: error.message };
+    }
+
+    const totals: Record<string, number> = {};
+    const names: Record<string, string> = {};
+
+    for (const task of (data as unknown as TimesheetEntry[]) || []) {
+      if (!task.project_id) continue;
+      totals[task.project_id] = (totals[task.project_id] || 0) + (task.time_tracked || 0);
+      if (task.project?.name) names[task.project_id] = task.project.name;
+    }
+
+    const reports: TimeReport[] = Object.entries(totals).map(([projectId, total]) => ({
+      projectId,
+      projectName: names[projectId] || '',
+      totalHours: total,
+    }));
+
+    return { reports, error: null };
+  } catch (error) {
+    console.error('Error in getTimeReports:', error);
+    return { reports: [] as TimeReport[], error: 'Failed to fetch time reports' };
+  }
+}

--- a/apps/web/app/(protected)/time/reports/page.tsx
+++ b/apps/web/app/(protected)/time/reports/page.tsx
@@ -1,0 +1,22 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { getTimeReports } from '@/actions/time';
+
+export default async function ReportsPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const workspaceId = session.user?.user_metadata?.current_workspace_id || '';
+  const { reports } = await getTimeReports(workspaceId);
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Time Reports</h1>
+        <p className="text-gray-600 mt-1">Summary of time spent by project</p>
+      </div>
+      {/* TODO: Render reports */}
+      <pre className="text-xs text-gray-500">{JSON.stringify(reports, null, 2)}</pre>
+    </main>
+  );
+}

--- a/apps/web/app/(protected)/time/timesheet/page.tsx
+++ b/apps/web/app/(protected)/time/timesheet/page.tsx
@@ -1,0 +1,22 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { getTimesheetEntries } from '@/actions/time';
+
+export default async function TimesheetPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const workspaceId = session.user?.user_metadata?.current_workspace_id || '';
+  const { entries } = await getTimesheetEntries(workspaceId);
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Timesheet</h1>
+        <p className="text-gray-600 mt-1">Review your tracked time</p>
+      </div>
+      {/* TODO: Render timesheet entries */}
+      <pre className="text-xs text-gray-500">{JSON.stringify(entries, null, 2)}</pre>
+    </main>
+  );
+}

--- a/tests/unit/timeRoutes.test.tsx
+++ b/tests/unit/timeRoutes.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import TimesheetPage from '../../apps/web/app/(protected)/time/timesheet/page';
+import ReportsPage from '../../apps/web/app/(protected)/time/reports/page';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('@/lib/user', () => ({
+  getSession: vi.fn().mockResolvedValue({
+    user: { user_metadata: { current_workspace_id: 'ws1' } }
+  })
+}));
+
+vi.mock('@/actions/time', () => ({
+  getTimesheetEntries: vi.fn().mockResolvedValue({ entries: [] }),
+  getTimeReports: vi.fn().mockResolvedValue({ reports: [] })
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn()
+}));
+
+describe('Time routes', () => {
+  it('renders timesheet page', async () => {
+    const Page = await TimesheetPage();
+    render(Page);
+    expect(screen.getByText(/timesheet/i)).toBeInTheDocument();
+  });
+
+  it('renders reports page', async () => {
+    const Page = await ReportsPage();
+    render(Page);
+    expect(screen.getByText(/time reports/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     alias: {
       react: path.resolve(__dirname, 'apps/web/node_modules/react'),
       'react-dom': path.resolve(__dirname, 'apps/web/node_modules/react-dom'),
+      '@': path.resolve(__dirname, 'apps/web'),
+      '@/*': path.resolve(__dirname, 'apps/web/*'),
+      'next/link': path.resolve(__dirname, 'apps/web/node_modules/next/dist/client/link.js'),
+      'next/navigation': path.resolve(
+        __dirname,
+        'apps/web/node_modules/next/dist/client/components/navigation.js'
+      ),
       '@ui': path.resolve(__dirname, 'packages/ui/src/index.ts'),
       '@ui/*': path.resolve(__dirname, 'packages/ui/src/*'),
       '@mad/db': path.resolve(__dirname, 'packages/db/src/index.ts'),


### PR DESCRIPTION
## Summary
- create initial timesheet and reports routes under `/time`
- fetch data using new server actions
- update Vitest config for Next.js aliases
- test rendering of new routes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc05a0da88322b7491918d25dc4b2