### PR TITLE
Fix db mocking path

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,10 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../types';
 
-export const supabaseClient = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  {
-    auth: { persistSession: false }
-  }
-); 
+export const createSupabaseClient = () =>
+  createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: { persistSession: false }
+    }
+  );
+
+export let supabaseClient = createSupabaseClient();
+
+export const setSupabaseClient = (
+  client: typeof supabaseClient
+) => {
+  supabaseClient = client;
+};
+

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createProject, createClient } from '@mad/db';
 
-vi.mock('@mad/db/src/client', () => ({
-  supabaseClient: {
+vi.mock('@mad/db', async () => {
+  const actual = await vi.importActual<typeof import('@mad/db')>('@mad/db');
+  const client = {
     from: () => ({
       insert: () => ({ select: () => ({ single: () => ({ data: {}, error: null }) }) })
     })
-  }
-}));
+  } as typeof actual.supabaseClient;
+  actual.setSupabaseClient(client);
+  return { ...actual, supabaseClient: client };
+});
 
 describe('DB helper', () => {
   it('validates input via zod', async () => {


### PR DESCRIPTION
## Summary
- expose a helper to replace `supabaseClient` in tests
- use `vi.mock('@mad/db')` instead of subpath mocks

## Testing
- `npx vitest run tests/unit/db.test.ts`
- `pnpm validate:all`


------
https://chatgpt.com/codex/tasks/task_e_685bc05ab8188322abbf061ddccbdf90