### PR TITLE
Add dashboard activity and analytics views

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { ProjectsGrid } from '@/components/projects';
 import { TaskTable } from '@/components/tasks';
 import { TaskSuggestions } from '@/components/ai/TaskSuggestions';
 import { SmartAnalytics } from '@/components/ai/SmartAnalytics';
+import { ActivityFeed } from '@/components/activity';
+import { AnalyticsWidgets } from '@/components/analytics';
 import { Plus, Download } from 'lucide-react';
 import type { Database } from '@mad/db';
 import { getProjects, createProject, getProjectStats } from '@/actions/projects';
@@ -123,7 +125,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(false);
   const searchParams = useSearchParams();
   const view = (searchParams.get('view') ?? 'overview') as
-    'overview' | 'ai-insights' | 'projects' | 'tasks';
+    'overview' | 'activity' | 'analytics' | 'ai-insights' | 'projects' | 'tasks';
   
   // Real data state
   const [projects, setProjects] = useState<Project[]>([]);
@@ -576,6 +578,49 @@ export default function DashboardPage() {
               </Card>
             </div>
           </div>
+        </div>
+      )}
+
+      {view === 'activity' && (
+        <div className="space-y-6">
+          <ActivityFeed items={recentActivity} />
+        </div>
+      )}
+
+      {view === 'analytics' && (
+        <div className="space-y-6">
+          <AnalyticsWidgets
+            widgets={[
+              {
+                id: 'projects',
+                title: 'Active Projects',
+                value: kpis.projects,
+                change: `${projects.filter(p => p.status === 'active').length} active`,
+                icon: '📁'
+              },
+              {
+                id: 'tasks',
+                title: 'Total Tasks',
+                value: kpis.tasks,
+                change: `${tasks.filter(t => t.status === 'in_progress').length} in progress`,
+                icon: '📋'
+              },
+              {
+                id: 'completed',
+                title: 'Completed Tasks',
+                value: kpis.completedTasks,
+                change: `${Math.round((kpis.completedTasks / Math.max(kpis.tasks, 1)) * 100)}% completion rate`,
+                icon: '✅'
+              },
+              {
+                id: 'team',
+                title: 'Team Members',
+                value: kpis.teamMembers,
+                change: 'Active contributors',
+                icon: '👥'
+              }
+            ]}
+          />
         </div>
       )}
 

--- a/apps/web/components/activity/ActivityFeed.tsx
+++ b/apps/web/components/activity/ActivityFeed.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Card } from '@ui';
+import type { ReactNode } from 'react';
+
+export interface ActivityItem {
+  id: string;
+  icon?: ReactNode;
+  message: string;
+  timestamp: string;
+  color?: string;
+}
+
+interface ActivityFeedProps {
+  items: ActivityItem[];
+  className?: string;
+}
+
+export function ActivityFeed({ items, className }: ActivityFeedProps) {
+  if (!items || items.length === 0) {
+    return (
+      <Card className={className + ' p-6'}>
+        <p className="text-center text-sm text-gray-500">No recent activity</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className + ' p-6'}>
+      <div className="space-y-3">
+        {items.map(item => (
+          <div key={item.id} className="flex items-start space-x-3">
+            {item.icon && (
+              <span className={`text-lg ${item.color ?? ''}`}>{item.icon}</span>
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-gray-900">{item.message}</p>
+              <p className="text-xs text-gray-500">{item.timestamp}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/components/activity/index.ts
+++ b/apps/web/components/activity/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityFeed';

--- a/apps/web/components/analytics/AnalyticsWidgets.tsx
+++ b/apps/web/components/analytics/AnalyticsWidgets.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { KpiCard, Button, Modal, Toggle } from '@ui';
+
+export interface AnalyticsWidget {
+  id: string;
+  title: string;
+  value: string | number;
+  change?: string;
+  icon?: ReactNode;
+}
+
+interface AnalyticsWidgetsProps {
+  widgets: AnalyticsWidget[];
+}
+
+export function AnalyticsWidgets({ widgets }: AnalyticsWidgetsProps) {
+  const [visible, setVisible] = useState<Record<string, boolean>>(() => {
+    const map: Record<string, boolean> = {};
+    widgets.forEach(w => {
+      map[w.id] = true;
+    });
+    return map;
+  });
+  const [open, setOpen] = useState(false);
+
+  const toggleWidget = (id: string) =>
+    setVisible(v => ({ ...v, [id]: !v[id] }));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button variant="secondary" onClick={() => setOpen(true)}>
+          Customize
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {widgets.filter(w => visible[w.id]).map(w => (
+          <KpiCard
+            key={w.id}
+            title={w.title}
+            value={w.value}
+            change={w.change}
+            icon={w.icon}
+          />
+        ))}
+      </div>
+      <Modal isOpen={open} onClose={() => setOpen(false)} title="Customize Widgets" size="sm">
+        <div className="space-y-3">
+          {widgets.map(w => (
+            <div key={w.id} className="flex items-center justify-between">
+              <span className="text-sm">{w.title}</span>
+              <Toggle enabled={visible[w.id]} onChange={() => toggleWidget(w.id)} />
+            </div>
+          ))}
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/components/analytics/index.ts
+++ b/apps/web/components/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from './AnalyticsWidgets';


### PR DESCRIPTION
## Summary
- add ActivityFeed and AnalyticsWidgets components
- handle `?view=activity` and `?view=analytics` in dashboard
- show activity feed and customizable analytics widgets

## Testing
- `pnpm validate:all`


------
https://chatgpt.com/codex/tasks/task_e_685bd4cc0448832290c5231d2fc723b6