### PR TITLE
Add timer context and new time pages

### DIFF
--- a/apps/web/app/(protected)/time/approvals/page.tsx
+++ b/apps/web/app/(protected)/time/approvals/page.tsx
@@ -1,18 +1,17 @@
 import { getSession } from '@/lib/user';
 import { redirect } from 'next/navigation';
-import { Timer } from '@/components/time/Timer';
 
-export default async function TimePage() {
+export default async function ApprovalsPage() {
   const session = await getSession();
   if (!session) redirect('/sign-in');
 
   return (
     <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Time</h1>
-        <p className="text-gray-600 mt-1">Track and review time entries</p>
+        <h1 className="text-3xl font-bold text-gray-900">Approvals</h1>
+        <p className="text-gray-600 mt-1">Review and approve time entries</p>
       </div>
-      <Timer />
+      <p className="text-gray-500 text-sm">Coming soon...</p>
     </main>
   );
 }

--- a/apps/web/app/(protected)/time/invoicing/page.tsx
+++ b/apps/web/app/(protected)/time/invoicing/page.tsx
@@ -1,18 +1,17 @@
 import { getSession } from '@/lib/user';
 import { redirect } from 'next/navigation';
-import { Timer } from '@/components/time/Timer';
 
-export default async function TimePage() {
+export default async function InvoicingPage() {
   const session = await getSession();
   if (!session) redirect('/sign-in');
 
   return (
     <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Time</h1>
-        <p className="text-gray-600 mt-1">Track and review time entries</p>
+        <h1 className="text-3xl font-bold text-gray-900">Invoicing</h1>
+        <p className="text-gray-600 mt-1">Generate invoices from tracked time</p>
       </div>
-      <Timer />
+      <p className="text-gray-500 text-sm">Coming soon...</p>
     </main>
   );
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'next-themes';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SupabaseProvider } from '@/lib/supabase-provider';
 import { AppProvider } from '@/contexts/AppContext';
+import { TimerProvider } from '@/contexts/TimerContext';
 import { ModalManager } from '@/components/ModalManager';
 import React from 'react';
 
@@ -19,8 +20,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <SupabaseProvider>
         <QueryClientProvider client={queryClient}>
           <AppProvider>
-            {children}
-            <ModalManager />
+            <TimerProvider>
+              {children}
+              <ModalManager />
+            </TimerProvider>
           </AppProvider>
         </QueryClientProvider>
       </SupabaseProvider>

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -71,7 +71,7 @@ const navigation: SidebarItem[] = [
       { id: 'completed', href: '/tasks?filter=completed', label: 'Completed' }
     ]
   },
-  { 
+  {
     id: 'time',
     href: '/time',
     label: 'Time',
@@ -79,7 +79,9 @@ const navigation: SidebarItem[] = [
     subItems: [
       { id: 'timer', href: '/time', label: 'Timer', icon: Clock },
       { id: 'timesheet', href: '/time/timesheet', label: 'Timesheet' },
-      { id: 'reports', href: '/time/reports', label: 'Reports' }
+      { id: 'reports', href: '/time/reports', label: 'Reports' },
+      { id: 'approvals', href: '/time/approvals', label: 'Approvals' },
+      { id: 'invoicing', href: '/time/invoicing', label: 'Invoicing' }
     ]
   },
   { 

--- a/apps/web/components/time/Timer.tsx
+++ b/apps/web/components/time/Timer.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Button } from '@ui';
+import { useTimer } from '@/contexts/TimerContext';
+
+function format(seconds: number) {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  const parts = [hrs, mins, secs].map(n => n.toString().padStart(2, '0'));
+  return parts.join(':');
+}
+
+export function Timer() {
+  const { isRunning, elapsed, start, pause, resume, reset } = useTimer();
+
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <div className="text-4xl font-bold text-gray-900">{format(elapsed)}</div>
+      <div className="space-x-2">
+        {!isRunning && elapsed === 0 && (
+          <Button onClick={start}>Start</Button>
+        )}
+        {isRunning && (
+          <Button variant="secondary" onClick={pause}>Pause</Button>
+        )}
+        {!isRunning && elapsed > 0 && (
+          <>
+            <Button onClick={resume}>Resume</Button>
+            <Button variant="secondary" onClick={reset}>Reset</Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/contexts/TimerContext.tsx
+++ b/apps/web/contexts/TimerContext.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface TimerContextValue {
+  isRunning: boolean;
+  elapsed: number; // seconds
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  reset: () => void;
+}
+
+const TimerContext = createContext<TimerContextValue | undefined>(undefined);
+
+export function TimerProvider({ children }: { children: ReactNode }) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  // Load stored timer state
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('timerState');
+    if (stored) {
+      try {
+        const data = JSON.parse(stored) as {
+          isRunning: boolean;
+          startTime: number | null;
+          elapsed: number;
+        };
+        setIsRunning(data.isRunning);
+        setStartTime(data.startTime);
+        setElapsed(data.elapsed);
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  // Persist timer state
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(
+      'timerState',
+      JSON.stringify({ isRunning, startTime, elapsed })
+    );
+  }, [isRunning, startTime, elapsed]);
+
+  // Tick when running
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+    if (isRunning && startTime) {
+      interval = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - startTime) / 1000));
+      }, 1000);
+    }
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [isRunning, startTime]);
+
+  const start = () => {
+    setStartTime(Date.now());
+    setElapsed(0);
+    setIsRunning(true);
+  };
+
+  const pause = () => {
+    if (startTime) {
+      setElapsed(Math.floor((Date.now() - startTime) / 1000));
+    }
+    setIsRunning(false);
+  };
+
+  const resume = () => {
+    setStartTime(Date.now() - elapsed * 1000);
+    setIsRunning(true);
+  };
+
+  const reset = () => {
+    setIsRunning(false);
+    setStartTime(null);
+    setElapsed(0);
+  };
+
+  return (
+    <TimerContext.Provider value={{ isRunning, elapsed, start, pause, resume, reset }}>
+      {children}
+    </TimerContext.Provider>
+  );
+}
+
+export function useTimer() {
+  const ctx = useContext(TimerContext);
+  if (!ctx) throw new Error('useTimer must be used within a TimerProvider');
+  return ctx;
+}

--- a/tests/unit/timeRoutes.test.tsx
+++ b/tests/unit/timeRoutes.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import TimesheetPage from '../../apps/web/app/(protected)/time/timesheet/page';
 import ReportsPage from '../../apps/web/app/(protected)/time/reports/page';
+import ApprovalsPage from '../../apps/web/app/(protected)/time/approvals/page';
+import InvoicingPage from '../../apps/web/app/(protected)/time/invoicing/page';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
@@ -30,5 +32,17 @@ describe('Time routes', () => {
     const Page = await ReportsPage();
     render(Page);
     expect(screen.getByText(/time reports/i)).toBeInTheDocument();
+  });
+
+  it('renders approvals page', async () => {
+    const Page = await ApprovalsPage();
+    render(Page);
+    expect(screen.getByText(/approvals/i)).toBeInTheDocument();
+  });
+
+  it('renders invoicing page', async () => {
+    const Page = await InvoicingPage();
+    render(Page);
+    expect(screen.getByText(/invoicing/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add TimerContext for running timer state persistence
- add Timer component
- integrate TimerProvider in app providers
- show running timer on `/time`
- add `approvals` and `invoicing` time subpages
- extend sidebar navigation for new pages
- test new time pages

## Testing
- `pnpm validate:all`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685bd4c5fa188322856e1958cdfb9563