### PR TITLE
Add messaging enhancements

### DIFF
--- a/apps/web/app/(protected)/messages/files/page.tsx
+++ b/apps/web/app/(protected)/messages/files/page.tsx
@@ -1,0 +1,29 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { getRecentMessages } from '@/actions/messages';
+
+export default async function FilesPage() {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const workspaceId = session.user?.user_metadata?.current_workspace_id || 'default-workspace';
+  const { messages } = await getRecentMessages(workspaceId, 50);
+  const files = messages.flatMap(m => (Array.isArray(m.attachments) ? m.attachments : []));
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <h1 className="text-3xl font-bold mb-4">Shared Files</h1>
+      {files.length === 0 ? (
+        <p>No files shared yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {files.map((file: { name: string }, idx: number) => (
+            <li key={idx} className="text-indigo-600 underline">
+              {file.name || 'File'}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/(protected)/messages/search/page.tsx
+++ b/apps/web/app/(protected)/messages/search/page.tsx
@@ -1,0 +1,45 @@
+import { getSession } from '@/lib/user';
+import { redirect } from 'next/navigation';
+import { searchMessages } from '@/actions/messages';
+
+interface SearchPageProps {
+  searchParams: { q?: string };
+}
+
+export default async function SearchMessagesPage({ searchParams }: SearchPageProps) {
+  const session = await getSession();
+  if (!session) redirect('/sign-in');
+
+  const workspaceId = session.user?.user_metadata?.current_workspace_id || 'default-workspace';
+  const query = searchParams.q ?? '';
+  const { messages } = query ? await searchMessages(workspaceId, query) : { messages: [] };
+
+  return (
+    <main className="flex-1 p-6 pt-24 md:p-8 md:pt-24">
+      <h1 className="text-3xl font-bold mb-4">Search Messages</h1>
+      <form className="mb-6">
+        <input
+          name="q"
+          defaultValue={query}
+          placeholder="Search..."
+          className="border rounded px-2 py-1"
+        />
+        <button type="submit" className="ml-2 px-3 py-1 bg-indigo-600 text-white rounded">
+          Search
+        </button>
+      </form>
+      {messages.length === 0 ? (
+        <p>No messages found.</p>
+      ) : (
+        <ul className="space-y-2">
+          {messages.map((m) => (
+            <li key={m.id} className="p-2 border rounded">
+              <div className="text-sm text-gray-600">{m.channel.name}</div>
+              <div>{m.text}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -91,7 +91,9 @@ const navigation: SidebarItem[] = [
     subItems: [
       { id: 'channels', href: '/messages', label: 'Channels', icon: MessageSquare },
       { id: 'direct', href: '/messages?view=direct', label: 'Direct Messages' },
-      { id: 'threads', href: '/messages?view=threads', label: 'Threads' }
+      { id: 'threads', href: '/messages?view=threads', label: 'Threads' },
+      { id: 'files', href: '/messages/files', label: 'Files' },
+      { id: 'search', href: '/messages/search', label: 'Search' }
     ]
   },
   { 


### PR DESCRIPTION
## Summary
- enhance sidebar navigation with files & search links
- filter messages by direct view or threads
- add threaded messaging, search filter, read receipts, typing indicator, and attachments
- add pages for shared files and message search

## Testing
- `pnpm validate:all`

------
https://chatgpt.com/codex/tasks/task_e_685bd4c8a6fc8322ad8decad51bfc88e