### PR TITLE
Improve layout gradients and sidebar effects

### DIFF
--- a/apps/web/app/(protected)/layout.tsx
+++ b/apps/web/app/(protected)/layout.tsx
@@ -33,12 +33,14 @@ export default async function ProtectedLayout({
   const currentWorkspace = workspaces[0] || null;
 
   return (
-    <ProtectedLayoutClient
-      user={user}
-      initialWorkspaces={workspaces}
-      initialCurrentWorkspace={currentWorkspace}
-    >
-      {children}
-    </ProtectedLayoutClient>
+    <div className="min-h-screen bg-app-light">
+      <ProtectedLayoutClient
+        user={user}
+        initialWorkspaces={workspaces}
+        initialCurrentWorkspace={currentWorkspace}
+      >
+        {children}
+      </ProtectedLayoutClient>
+    </div>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -81,6 +81,19 @@
     box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.5);
   }
 
+  /* Background gradients */
+  .bg-app-light {
+    @apply bg-gradient-to-br from-gray-50 to-white;
+  }
+
+  .dark .bg-app-light {
+    @apply from-gray-900 to-gray-950;
+  }
+
+  .glass .bg-app-light {
+    @apply from-white/20 to-white/5 backdrop-blur-2xl;
+  }
+
   /* Custom scrollbar styles */
   .custom-scrollbar::-webkit-scrollbar {
     width: 6px;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,9 +16,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={`${inter.className} min-h-screen bg-app-light`}>
         <Providers>{children}</Providers>
       </body>
     </html>
   );
-} 
+}

--- a/apps/web/components/messages/MessagesInterface.tsx
+++ b/apps/web/components/messages/MessagesInterface.tsx
@@ -440,7 +440,11 @@ export function MessagesInterface({
                         </div>
 
                         {/* Messages */}
-                        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+                        <div
+                            className="flex-1 overflow-y-auto p-4 space-y-4"
+                            role="region"
+                            aria-live="polite"
+                        >
                             <div className="mb-4">
                                 <Input
                                     placeholder="Search messages"

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -190,7 +190,7 @@ export default function Sidebar() {
                   href={item.href}
                   onClick={() => setSelectedMain(item.id)}
                   className={clsx(
-                    'w-full h-14 flex items-center justify-center rounded-xl group relative transition-all duration-300',
+                    'w-full h-14 flex items-center justify-center rounded-xl group relative transition-all duration-300 transition-shadow hover:shadow-md',
                     isActive
                       ? clsx(
                           'text-indigo-600 bg-gray-100/80 dark:text-indigo-400 dark:bg-gray-800/50',
@@ -289,7 +289,7 @@ export default function Sidebar() {
                       key={subItem.id}
                       href={subItem.href}
                       className={clsx(
-                        'flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 group relative',
+                        'flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 transition-shadow group relative',
                         isSubActive
                           ? clsx(
                               'bg-gray-200/80 text-gray-900 dark:bg-gray-800 dark:text-gray-100',


### PR DESCRIPTION
## Summary
- add gradient utility classes and use them in layouts
- enhance sidebar with shadow transitions
- include aria-live region in MessagesInterface for accessibility

## Testing
- `pnpm lint` *(fails: network access needed)*
- `pnpm typecheck` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc4f12fc832283a1296a92a81eba