### PR TITLE
Fix workspace dropdown to display active workspace

### DIFF
--- a/apps/web/app/(protected)/layout.tsx
+++ b/apps/web/app/(protected)/layout.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/lib/user';
 import { redirect } from 'next/navigation';
 import ProtectedLayoutClient from './ProtectedLayoutClient';
 import { getWorkspaces } from '@/actions/workspace';
+import { cookies } from 'next/headers';
 
 type Workspace = {
   id: string;
@@ -30,7 +31,14 @@ export default async function ProtectedLayout({
   const userId = session.user.id;
   const { workspaces: rawWorkspaces } = await getWorkspaces(userId);
   const workspaces = rawWorkspaces as Workspace[];
-  const currentWorkspace = workspaces[0] || null;
+
+  const cookieStore = cookies();
+  const storedId = cookieStore.get('currentWorkspaceId')?.value;
+  let currentWorkspace = workspaces[0] || null;
+  if (storedId) {
+    const found = workspaces.find(w => w.id === storedId);
+    if (found) currentWorkspace = found;
+  }
 
   return (
     <ProtectedLayoutClient

--- a/apps/web/components/workspace/WorkspaceSelection.tsx
+++ b/apps/web/components/workspace/WorkspaceSelection.tsx
@@ -64,6 +64,7 @@ export function WorkspaceSelection({ userId, initialWorkspaces, initialInvitatio
     dispatch({ type: 'SET_CURRENT_WORKSPACE', payload: workspace });
     if (typeof window !== 'undefined') {
       localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
+      document.cookie = `currentWorkspaceId=${workspace.id}; path=/`;
     }
     router.push('/dashboard');
   };

--- a/apps/web/components/workspace/WorkspaceSwitcher.tsx
+++ b/apps/web/components/workspace/WorkspaceSwitcher.tsx
@@ -21,6 +21,7 @@ export function WorkspaceSwitcher() {
         dispatch({ type: 'SET_CURRENT_WORKSPACE', payload: workspace });
         if (typeof window !== 'undefined') {
             localStorage.setItem('currentWorkspace', JSON.stringify(workspace));
+            document.cookie = `currentWorkspaceId=${workspace.id}; path=/`;
         }
         router.push('/dashboard');
     };
@@ -161,6 +162,7 @@ export function WorkspaceSwitcher() {
                                             'currentWorkspace',
                                             JSON.stringify(workspace)
                                         );
+                                        document.cookie = `currentWorkspaceId=${workspace.id}; path=/`;
                                     }
                                     router.push('/dashboard');
                                 });


### PR DESCRIPTION
## Summary
- persist current workspace in a cookie whenever it changes
- read this cookie in the protected layout so the server selects the correct workspace

## Testing
- `pnpm lint` *(fails: fetch failed - registry.npmjs.org)*
- `pnpm typecheck` *(fails: fetch failed - registry.npmjs.org)*
- `pnpm test` *(fails: fetch failed - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685c09078290832298a5c6125e87b028