### PR TITLE
UI improvements and error handling for messages

### DIFF
--- a/apps/web/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/web/app/(protected)/ProtectedLayoutClient.tsx
@@ -65,7 +65,7 @@ export default function ProtectedLayoutClient({
     }
   }, [dispatch, user, initialWorkspaces, initialCurrentWorkspace]);
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-950 glass:from-white/10 glass:to-white/5">
       <Sidebar />
       <div className="flex-1 flex flex-col ml-[368px]"> {/* 80px + 288px */}
         <Header user={user} />

--- a/apps/web/app/(protected)/messages/error.tsx
+++ b/apps/web/app/(protected)/messages/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center p-8">
+      <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Something went wrong</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-4">Unable to load messages.</p>
+      <button
+        onClick={() => reset()}
+        className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 focus-visible-ring"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/messages/page.tsx
+++ b/apps/web/app/(protected)/messages/page.tsx
@@ -86,6 +86,10 @@ async function MessagesContent({
     channelList = channels.filter(ch => ch.type === 'direct');
   }
 
+  if (!channelList || channelList.length === 0) {
+    return <p>No channels found for this view.</p>;
+  }
+
   let currentChannel: Channel | null = null;
   if (channelList.length > 0) {
     if (searchParams.channel) {
@@ -98,7 +102,9 @@ async function MessagesContent({
   let messages: Message[] = [];
   if (currentChannel) {
     const { messages: channelMessages, error: messagesError } = await getMessages(currentChannel.id);
-    if (!messagesError) {
+    if (messagesError) {
+      console.error('Error loading messages:', messagesError);
+    } else {
       messages = channelMessages;
     }
   }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -61,7 +61,7 @@
   }
   
   body {
-    @apply bg-background text-foreground;
+    @apply min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-950 glass:from-white/10 glass:to-white/5 text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }

--- a/apps/web/components/messages/MessagesInterface.tsx
+++ b/apps/web/components/messages/MessagesInterface.tsx
@@ -82,6 +82,14 @@ export function MessagesInterface({
     const { presence, sendPresence } = usePresence(currentChannel?.id || '');
     const { broadcastUpdate } = useCollaborativeEditing(currentChannel?.id || '', () => {});
 
+    if (channels.length === 0) {
+        return (
+            <div className="flex-1 flex items-center justify-center text-gray-500 p-4">
+                <p>No channels available.</p>
+            </div>
+        );
+    }
+
     const displayedMessages = useMemo(() => {
         if (!currentChannel) return [];
         let result = messages;

--- a/apps/web/components/sidebar/Sidebar.tsx
+++ b/apps/web/components/sidebar/Sidebar.tsx
@@ -188,9 +188,9 @@ export default function Sidebar() {
                     className={clsx(
                       "absolute left-0 top-1/2 -translate-y-1/2 w-1 h-10 rounded-r-full",
                       "bg-indigo-500 dark:bg-indigo-400",
-                      "shadow-md shadow-indigo-500/20 dark:shadow-indigo-400/20",
+                      "shadow-lg shadow-indigo-500/20 dark:shadow-indigo-400/20",
                       "glass:bg-white/80 glass:shadow-[0_0_20px_rgba(255,255,255,0.5)]",
-                      "transition-colors transition-shadow duration-300"
+                      "transition-all duration-300"
                     )}
                   />
                 )}
@@ -199,10 +199,10 @@ export default function Sidebar() {
                   href={item.href}
                   onClick={() => setSelectedMain(item.id)}
                   className={clsx(
-                    'w-full h-14 flex items-center justify-center rounded-xl group relative transition-colors transition-shadow duration-300',
+                    'w-full h-14 flex items-center justify-center rounded-xl group relative transition-all duration-300',
                     isActive
                       ? clsx(
-                          'text-indigo-600 bg-gray-100/80 dark:text-indigo-400 dark:bg-gray-800/50 shadow-md shadow-indigo-500/10 dark:shadow-indigo-400/10',
+                          'text-indigo-600 bg-gray-100/80 dark:text-indigo-400 dark:bg-gray-800/50 shadow-lg shadow-indigo-500/10 dark:shadow-indigo-400/10',
                           'glass:text-white glass:bg-white/20 glass:shadow-[0_8px_32px_0_rgba(255,255,255,0.1)]'
                         )
                       : clsx(
@@ -250,7 +250,7 @@ export default function Sidebar() {
                       "bg-gray-900 text-white dark:bg-gray-800",
                       "glass:bg-black/80 glass:backdrop-blur-xl glass:border glass:border-white/20",
                       "text-sm opacity-0 group-hover:opacity-100",
-                      "transition-colors transition-shadow duration-200 whitespace-nowrap pointer-events-none z-10",
+                      "transition-colors transition-shadow duration-300 whitespace-nowrap pointer-events-none z-10",
                       "shadow-xl"
                     )}
                   >
@@ -307,7 +307,7 @@ export default function Sidebar() {
                       key={subItem.id}
                       href={subItem.href}
                       className={clsx(
-                        'flex items-center gap-3 px-3 py-2 rounded-lg transition-colors transition-shadow duration-200 group relative',
+                        'flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-300 group relative',
                         isSubActive
                           ? clsx(
                               'bg-gray-200/80 text-gray-900 dark:bg-gray-800 dark:text-gray-100 shadow-sm dark:shadow-black/10',


### PR DESCRIPTION
## Summary
- tweak sidebar transitions and shadow effects
- add gradient background to protected layout
- refine messages page error handling and add error boundary
- handle empty channel lists gracefully
- update global styles for layout gradient

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.6.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.6.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.6.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685c08ea03ac832284dc8c19b70d4607