### PR TITLE
Remove showTabs override in directory page

### DIFF
--- a/apps/web/app/(protected)/directory/page.tsx
+++ b/apps/web/app/(protected)/directory/page.tsx
@@ -102,7 +102,6 @@ export default async function Directory({ searchParams }: DirectoryPageProps) {
         employees={employees}
         companies={companies}
         initialTab={view}
-        showTabs={false}
       />
     </main>
   );


### PR DESCRIPTION
## Summary
- remove the `showTabs` prop so it uses the default

## Testing
- `pnpm lint` *(fails: MessagesInterface has existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c19a537cc83229cfd8b5547001fba