### PR TITLE
Add EmptyState component and integrate into directory tabs

### DIFF
--- a/apps/web/components/directory/DirectoryTabs.tsx
+++ b/apps/web/components/directory/DirectoryTabs.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import { Tabs, TabsList, TabsTrigger, TabsContent, Card, Button, Avatar, Badge, Input, Modal, Select, Toast } from '@ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent, Card, Button, Avatar, Badge, Input, Modal, Select, Toast, EmptyState } from '@ui';
 import { Search, Plus, Mail, Phone, Building, Calendar, Users, MessageCircle, Settings } from 'lucide-react';
 import { inviteTeamMember } from '@/actions/workspace';
 import { createDirectMessage } from '@/actions/messages';
@@ -209,9 +209,10 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                     </div>
 
                     {/* Members Grid */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredMembers.map((member) => (
-                            <Card key={member.id} className="p-6">
+                    {filteredMembers.length > 0 ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {filteredMembers.map((member) => (
+                                <Card key={member.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <Avatar
                                         src={member.avatar_url}
@@ -258,9 +259,26 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                         Edit
                                     </Button>
                                 </div>
-                            </Card>
-                        ))}
-                    </div>
+                                </Card>
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyState
+                            message={
+                                searchQuery
+                                    ? `No members found for "${searchQuery}"`
+                                    : 'No members yet'
+                            }
+                            action={
+                                !searchQuery && (
+                                    <Button onClick={() => setShowAddMember(true)} variant="primary">
+                                        <Plus className="h-4 w-4 mr-2" />
+                                        Add Member
+                                    </Button>
+                                )
+                            }
+                        />
+                    )}
                 </div>
             )
         },
@@ -288,9 +306,10 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                     </div>
 
                     {/* Employees Grid */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredEmployees.map((employee) => (
-                            <Card key={employee.id} className="p-6">
+                    {filteredEmployees.length > 0 ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {filteredEmployees.map((employee) => (
+                                <Card key={employee.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <Avatar
                                         initials={employee.name.split(' ').map(n => n[0]).join('')}
@@ -332,9 +351,26 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                         Edit
                                     </Button>
                                 </div>
-                            </Card>
-                        ))}
-                    </div>
+                                </Card>
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyState
+                            message={
+                                searchQuery
+                                    ? `No employees found for "${searchQuery}"`
+                                    : 'No employees yet'
+                            }
+                            action={
+                                !searchQuery && (
+                                    <Button onClick={() => setShowAddEmployee(true)} variant="primary">
+                                        <Plus className="h-4 w-4 mr-2" />
+                                        Add Employee
+                                    </Button>
+                                )
+                            }
+                        />
+                    )}
                 </div>
             )
         },
@@ -362,9 +398,10 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                     </div>
 
                     {/* Companies Grid */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredCompanies.map((company) => (
-                            <Card key={company.id} className="p-6">
+                    {filteredCompanies.length > 0 ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {filteredCompanies.map((company) => (
+                                <Card key={company.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
                                         <Building className="h-6 w-6 text-gray-600" />
@@ -405,9 +442,26 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                         Edit
                                     </Button>
                                 </div>
-                            </Card>
-                        ))}
-                    </div>
+                                </Card>
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyState
+                            message={
+                                searchQuery
+                                    ? `No companies found for "${searchQuery}"`
+                                    : 'No companies yet'
+                            }
+                            action={
+                                !searchQuery && (
+                                    <Button onClick={() => setShowAddCompany(true)} variant="primary">
+                                        <Plus className="h-4 w-4 mr-2" />
+                                        Add Company
+                                    </Button>
+                                )
+                            }
+                        />
+                    )}
                 </div>
             )
         }

--- a/packages/ui/src/EmptyState.tsx
+++ b/packages/ui/src/EmptyState.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  /** Message to display */
+  message: string;
+  /** Optional call-to-action element */
+  action?: ReactNode;
+  className?: string;
+}
+
+export const EmptyState = ({ message, action, className }: EmptyStateProps) => (
+  <div className={clsx('flex flex-col items-center justify-center py-10 space-y-4 text-center', className)}>
+    <p className="text-sm text-gray-500">{message}</p>
+    {action}
+  </div>
+);
+
+EmptyState.displayName = 'EmptyState';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,5 +13,6 @@ export * from './Dropdown';
 export * from './Modal';
 export * from './Tabs';
 export * from './Toast';
+export * from './EmptyState';
 export * from './components/layout/SubNav/SubNav';
 export * from './PresenceIndicator';


### PR DESCRIPTION
## Summary
- add `EmptyState` UI component
- export from `@ui`
- show `EmptyState` when directory tabs have no data or search results

## Testing
- `pnpm lint` *(fails: MessagesInterface hooks issue)*
- `pnpm typecheck`
- `pnpm test`
- `pnpm validate:all` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685c19ab64548322b0982fbd19abfa53