### PR TITLE
Implement server auth actions

### DIFF
--- a/apps/web/actions/auth.ts
+++ b/apps/web/actions/auth.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { createClient } from '@/lib/supabase-server';
+
+export async function signIn(email: string, password: string) {
+  const supabase = createClient();
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      return { user: null, error: error.message };
+    }
+    return { user: data.user, error: null };
+  } catch (err) {
+    console.error('Sign in error:', err);
+    return { user: null, error: 'Failed to sign in' };
+  }
+}
+
+export async function signUp(email: string, password: string, name: string) {
+  const supabase = createClient();
+  const redirectTo = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}/auth/callback`
+    : 'http://localhost:3000/auth/callback';
+  try {
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: { name },
+        emailRedirectTo: redirectTo,
+      },
+    });
+    if (error) {
+      return { user: null, error: error.message };
+    }
+    return { user: data.user, error: null };
+  } catch (err) {
+    console.error('Sign up error:', err);
+    return { user: null, error: 'Failed to sign up' };
+  }
+}
+
+export async function signOut() {
+  const supabase = createClient();
+  try {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      return { error: error.message };
+    }
+    return { error: null };
+  } catch (err) {
+    console.error('Sign out error:', err);
+    return { error: 'Failed to sign out' };
+  }
+}

--- a/apps/web/app/(auth)/sign-in/SignInForm.tsx
+++ b/apps/web/app/(auth)/sign-in/SignInForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { signIn } from '@/actions/auth';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { Button, Card } from '@ui';
@@ -13,7 +13,6 @@ export default function SignInForm() {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = supabaseBrowser();
 
   // Handle URL error parameters
   useEffect(() => {
@@ -48,19 +47,14 @@ export default function SignInForm() {
     setLoading(true);
 
     try {
-      const { data, error: authError } = await supabase.auth.signInWithPassword({
-        email,
-        password
-      });
+      const { error } = await signIn(email, password);
 
-      if (authError) {
-        setError(authError.message);
+      if (error) {
+        setError(error);
         return;
       }
 
-      if (data?.user) {
-        router.push('/workspace-selection');
-      }
+      router.push('/workspace-selection');
     } catch (err) {
       setError('An unexpected error occurred. Please try again.');
       console.error('Sign-in error:', err);

--- a/apps/web/app/(auth)/sign-up/page.tsx
+++ b/apps/web/app/(auth)/sign-up/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { signUp } from '@/actions/auth';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { Button, Card, Badge } from '@ui';
@@ -40,7 +40,6 @@ export default function SignUp() {
   ]);
 
   const router = useRouter();
-  const supabase = supabaseBrowser();
 
   // Calculate password strength
   useEffect(() => {
@@ -105,22 +104,15 @@ export default function SignUp() {
     setLoading(true);
 
     try {
-      const { data, error: authError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: { name },
-          emailRedirectTo: `${window.location.origin}/auth/callback`
-        }
-      });
+      const { user, error: authError } = await signUp(email, password, name);
 
       if (authError) {
-        setError(authError.message);
+        setError(authError);
         return;
       }
 
-      if (data?.user) {
-        if (data.user.email_confirmed_at) {
+      if (user) {
+        if (user.email_confirmed_at) {
           router.push('/workspace-selection');
         } else {
           setSuccess(true);

--- a/apps/web/components/header/Header.tsx
+++ b/apps/web/components/header/Header.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Search, Bell, Sun, Moon, ChevronDown, LogOut, Settings, User, Command } from 'lucide-react';
 import Image from 'next/image';
 import { useTheme } from 'next-themes';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { signOut } from '@/actions/auth';
 import { useRouter } from 'next/navigation';
 import { Dropdown, DropdownItem, Badge, Input } from '@ui';
 import { searchUsers } from '@/actions/workspace';
@@ -38,11 +38,10 @@ export default function Header({ user }: HeaderProps) {
   ]);
   const searchRef = useRef<HTMLDivElement>(null);
 
-  const supabase = supabaseBrowser();
   const unreadCount = notifications.filter(n => !n.read).length;
 
-  const signOut = async () => {
-    await supabase.auth.signOut();
+  const handleSignOut = async () => {
+    await signOut();
     router.refresh();
   };
 
@@ -273,7 +272,7 @@ export default function Header({ user }: HeaderProps) {
             Settings
           </DropdownItem>
           <div className="border-t border-gray-200 dark:border-gray-700 my-1"></div>
-          <DropdownItem onClick={signOut} className="text-red-600 dark:text-red-400">
+          <DropdownItem onClick={handleSignOut} className="text-red-600 dark:text-red-400">
             <LogOut className="h-4 w-4 mr-2" />
             Sign out
           </DropdownItem>


### PR DESCRIPTION
## Summary
- add server-side authentication actions
- refactor sign-in and sign-up forms to use the new actions
- update header component to sign out via server

## Testing
- `pnpm lint` *(fails: react-hooks/rules-of-hooks)*
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c51f652a0832282665cd99d38c4e8