### PR TITLE
Add EmptyState UI component and show in DirectoryTabs

### DIFF
--- a/apps/web/components/directory/DirectoryTabs.tsx
+++ b/apps/web/components/directory/DirectoryTabs.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import { Tabs, TabsList, TabsTrigger, TabsContent, Card, Button, Avatar, Badge, Input, Modal, Select, Toast } from '@ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent, Card, Button, Avatar, Badge, Input, Modal, Select, Toast, EmptyState } from '@ui';
 import { Search, Plus, Mail, Phone, Building, Calendar, Users, MessageCircle, Settings } from 'lucide-react';
 import { inviteTeamMember } from '@/actions/workspace';
 import { createDirectMessage } from '@/actions/messages';
@@ -210,7 +210,21 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
 
                     {/* Members Grid */}
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredMembers.map((member) => (
+                        {filteredMembers.length === 0 ? (
+                            <EmptyState
+                                className="col-span-full"
+                                message={searchQuery ? 'No members match your search.' : 'No members found.'}
+                                cta={
+                                    searchQuery ? undefined : (
+                                        <Button variant="primary" onClick={() => setShowAddMember(true)}>
+                                            <Plus className="h-4 w-4 mr-2" />
+                                            Add Member
+                                        </Button>
+                                    )
+                                }
+                            />
+                        ) : (
+                            filteredMembers.map((member) => (
                             <Card key={member.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <Avatar
@@ -259,7 +273,8 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                     </Button>
                                 </div>
                             </Card>
-                        ))}
+                            ))
+                        )}
                     </div>
                 </div>
             )
@@ -289,7 +304,21 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
 
                     {/* Employees Grid */}
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredEmployees.map((employee) => (
+                        {filteredEmployees.length === 0 ? (
+                            <EmptyState
+                                className="col-span-full"
+                                message={searchQuery ? 'No employees match your search.' : 'No employees found.'}
+                                cta={
+                                    searchQuery ? undefined : (
+                                        <Button variant="primary" onClick={() => setShowAddEmployee(true)}>
+                                            <Plus className="h-4 w-4 mr-2" />
+                                            Add Employee
+                                        </Button>
+                                    )
+                                }
+                            />
+                        ) : (
+                            filteredEmployees.map((employee) => (
                             <Card key={employee.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <Avatar
@@ -333,7 +362,8 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                     </Button>
                                 </div>
                             </Card>
-                        ))}
+                            ))
+                        )}
                     </div>
                 </div>
             )
@@ -363,7 +393,21 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
 
                     {/* Companies Grid */}
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredCompanies.map((company) => (
+                        {filteredCompanies.length === 0 ? (
+                            <EmptyState
+                                className="col-span-full"
+                                message={searchQuery ? 'No companies match your search.' : 'No companies found.'}
+                                cta={
+                                    searchQuery ? undefined : (
+                                        <Button variant="primary" onClick={() => setShowAddCompany(true)}>
+                                            <Plus className="h-4 w-4 mr-2" />
+                                            Add Company
+                                        </Button>
+                                    )
+                                }
+                            />
+                        ) : (
+                            filteredCompanies.map((company) => (
                             <Card key={company.id} className="p-6">
                                 <div className="flex items-center space-x-4">
                                     <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
@@ -406,7 +450,8 @@ export function DirectoryTabs({ workspaceId, currentUserId, members, employees, 
                                     </Button>
                                 </div>
                             </Card>
-                        ))}
+                            ))
+                        )}
                     </div>
                 </div>
             )

--- a/packages/ui/src/EmptyState.tsx
+++ b/packages/ui/src/EmptyState.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  message: string;
+  cta?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({ message, cta, className }: EmptyStateProps) {
+  return (
+    <div
+      className={clsx(
+        'py-8 text-center text-gray-500 flex flex-col items-center space-y-4',
+        className
+      )}
+    >
+      <p>{message}</p>
+      {cta && <div>{cta}</div>}
+    </div>
+  );
+}
+
+EmptyState.displayName = 'EmptyState';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,3 +15,4 @@ export * from './Tabs';
 export * from './Toast';
 export * from './components/layout/SubNav/SubNav';
 export * from './PresenceIndicator';
+export * from './EmptyState';


### PR DESCRIPTION
## Summary
- add an `EmptyState` component for simple empty lists
- export the component from `@ui`
- display `EmptyState` in directory tabs when a tab has no items

## Testing
- `pnpm validate:all` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_685c69ddae60832288de3203e61eea70