### PR TITLE
Handle directory load errors

### DIFF
--- a/apps/web/app/(protected)/directory/page.tsx
+++ b/apps/web/app/(protected)/directory/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/lib/user';
 import { redirect } from 'next/navigation';
 import { DirectoryTabs } from '@/components/directory/DirectoryTabs';
 import { getTeamMembers } from '@/actions/workspace';
+import { X } from 'lucide-react';
 
 interface DirectoryPageProps {
   searchParams: { view?: string };
@@ -19,6 +20,12 @@ export default async function Directory({ searchParams }: DirectoryPageProps) {
 
   // Load real team members from database
   const { members, error } = await getTeamMembers(workspaceId);
+
+  let errorMessage: string | null = null;
+  if (error) {
+    console.error('Error loading directory data:', error);
+    errorMessage = 'Failed to load directory data. Please try again later.';
+  }
 
   // Map team members to the expected format
   const formattedMembers = members.map(member => ({
@@ -82,9 +89,7 @@ export default async function Directory({ searchParams }: DirectoryPageProps) {
     },
   ];
 
-  if (error) {
-    console.error('Error loading directory data:', error);
-  }
+
 
   return (
     <section className="pt-24">
@@ -96,6 +101,18 @@ export default async function Directory({ searchParams }: DirectoryPageProps) {
           </p>
         </div>
       </div>
+
+      {errorMessage && (
+        <div className="mb-6 mx-6 md:mx-8 p-4 rounded-lg bg-red-50 border border-red-200">
+          <div className="flex items-center space-x-2">
+            <X className="h-5 w-5 text-red-600 flex-shrink-0" />
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Error</h3>
+              <p className="text-sm text-red-700 mt-1">{errorMessage}</p>
+            </div>
+          </div>
+        </div>
+      )}
 
       <DirectoryTabs
         workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- display an inline alert when directory members fail to load

## Testing
- `pnpm lint` *(fails: unable to fetch packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ce7f3fc8322855b99ed33b9ae39